### PR TITLE
Integrate shopeego for token refresh

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.10.9
 	github.com/spf13/viper v1.20.1
+	github.com/teacat/shopeego v1.3.3
 	github.com/xuri/excelize/v2 v2.7.0
 )
 

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -149,6 +149,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/teacat/shopeego v1.3.3 h1:XVdhxoENx55W+s2nrCJAo9JE2FXJSJxIgv79e04KivQ=
+github.com/teacat/shopeego v1.3.3/go.mod h1:DtyGPQgr2bacmw1Bu/5UK4cTbQ6SOMLASBnStZeEeUU=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=


### PR DESCRIPTION
## Summary
- replace custom refresh logic with `shopeego` client
- adjust tests for new JSON request body
- add `github.com/teacat/shopeego` dependency

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686be1a945dc83279783e3054b976f5b