### PR TITLE
Add escrow detail check for completed orders

### DIFF
--- a/backend/internal/handlers/reconcile_extra_handler.go
+++ b/backend/internal/handlers/reconcile_extra_handler.go
@@ -17,6 +17,7 @@ type ReconcileExtraService interface {
 	CheckAndMarkComplete(ctx context.Context, kodePesanan string) error
 	GetShopeeOrderStatus(ctx context.Context, invoice string) (string, error)
 	GetShopeeOrderDetail(ctx context.Context, invoice string) (*service.ShopeeOrderDetail, error)
+	GetShopeeEscrowDetail(ctx context.Context, invoice string) (*service.ShopeeEscrowDetail, error)
 	GetShopeeAccessToken(ctx context.Context, invoice string) (string, error)
 	CancelPurchase(ctx context.Context, kodePesanan string) error
 	UpdateShopeeStatus(ctx context.Context, invoice string) error
@@ -37,6 +38,7 @@ func (h *ReconcileExtraHandler) RegisterRoutes(r gin.IRouter) {
 	grp.POST("/cancel", h.cancel)
 	grp.POST("/update_status", h.updateStatus)
 	grp.GET("/status", h.status)
+	grp.GET("/escrow", h.escrow)
 	grp.GET("/token", h.token)
 }
 
@@ -126,6 +128,20 @@ func (h *ReconcileExtraHandler) status(c *gin.Context) {
 		return
 	}
 	detail, err := h.svc.GetShopeeOrderDetail(context.Background(), invoice)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, detail)
+}
+
+func (h *ReconcileExtraHandler) escrow(c *gin.Context) {
+	invoice := c.Query("invoice")
+	if invoice == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing invoice"})
+		return
+	}
+	detail, err := h.svc.GetShopeeEscrowDetail(context.Background(), invoice)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/service/shopee_escrow_detail.go
+++ b/backend/internal/service/shopee_escrow_detail.go
@@ -1,0 +1,5 @@
+package service
+
+// ShopeeEscrowDetail represents the escrow detail structure returned by Shopee.
+// It uses a flexible map so any new fields are preserved automatically.
+type ShopeeEscrowDetail map[string]any

--- a/frontend/dropship-erp-ui/src/api/reconcile.ts
+++ b/frontend/dropship-erp-ui/src/api/reconcile.ts
@@ -43,6 +43,10 @@ export function fetchShopeeDetail(invoice: string) {
   return api.get<ShopeeOrderDetail>(`/reconcile/status?invoice=${invoice}`);
 }
 
+export function fetchEscrowDetail(invoice: string) {
+  return api.get<ShopeeOrderDetail>(`/reconcile/escrow?invoice=${invoice}`);
+}
+
 export function fetchShopeeToken(invoice: string) {
   return api.get<{ access_token: string }>(
     `/reconcile/token?invoice=${invoice}`,

--- a/frontend/dropship-erp-ui/src/components/ReconcileDashboard.test.tsx
+++ b/frontend/dropship-erp-ui/src/components/ReconcileDashboard.test.tsx
@@ -17,6 +17,9 @@ jest.mock("../api/reconcile", () => ({
   fetchShopeeDetail: jest.fn().mockResolvedValue({
     data: { order_sn: "INV", order_status: "PROCESSED" },
   }),
+  fetchEscrowDetail: jest.fn().mockResolvedValue({
+    data: { order_sn: "INV", escrow_amount: 1000 },
+  }),
 }));
 
 beforeEach(() => {
@@ -146,6 +149,34 @@ test("check status button", async () => {
   fireEvent.click(screen.getByRole("button", { name: /Check Status/i }));
   await waitFor(() =>
     expect(api.fetchShopeeDetail).toHaveBeenCalledWith("INV"),
+  );
+});
+
+test("check status completed uses escrow endpoint", async () => {
+  (api.listCandidates as jest.Mock).mockResolvedValueOnce({
+    data: {
+      data: [
+        {
+          kode_pesanan: "A",
+          kode_invoice_channel: "INV",
+          nama_toko: "X",
+          status_pesanan_terakhir: "selesai",
+          no_pesanan: "INV",
+          shopee_order_status: "COMPLETED",
+        },
+      ],
+      total: 1,
+    },
+  });
+  render(
+    <MemoryRouter>
+      <ReconcileDashboard />
+    </MemoryRouter>,
+  );
+  await screen.findByRole("button", { name: /Check Status/i });
+  fireEvent.click(screen.getByRole("button", { name: /Check Status/i }));
+  await waitFor(() =>
+    expect(api.fetchEscrowDetail).toHaveBeenCalledWith("INV"),
   );
 });
 

--- a/frontend/dropship-erp-ui/src/components/ReconcileDashboard.tsx
+++ b/frontend/dropship-erp-ui/src/components/ReconcileDashboard.tsx
@@ -18,6 +18,8 @@ import {
   reconcileCheck,
   cancelPurchase,
   updateShopeeStatus,
+  fetchEscrowDetail,
+  fetchShopeeDetail,
 } from "../api/reconcile";
 import { listAllStores } from "../api";
 import type { ReconcileCandidate, Store, ShopeeOrderDetail } from "../types";
@@ -76,9 +78,10 @@ export default function ReconcileDashboard() {
     }
   };
 
-  const handleCheckStatus = async (inv: string) => {
+  const handleCheckStatus = async (inv: string, status: string) => {
     try {
-      const res = await fetchShopeeDetail(inv);
+      const apiCall = status.toLowerCase() === "completed" ? fetchEscrowDetail : fetchShopeeDetail;
+      const res = await apiCall(inv);
       setDetail(res.data);
       setDetailInvoice(inv);
       setDetailOpen(true);
@@ -165,7 +168,7 @@ export default function ReconcileDashboard() {
       render: (_, row) => (
         <Button
           size="small"
-          onClick={() => handleCheckStatus(row.kode_invoice_channel)}
+          onClick={() => handleCheckStatus(row.kode_invoice_channel, row.shopee_order_status)}
         >
           Check Status
         </Button>


### PR DESCRIPTION
## Summary
- show escrow details for completed orders via new endpoint
- implement Shopee escrow detail retrieval with shopeego
- wire up API route and handler
- handle escrow detail in ReconcileDashboard component and tests

## Testing
- `gofmt -w backend/internal/handlers/reconcile_extra_handler.go backend/internal/service/reconcile_service.go backend/internal/service/shopee_client.go backend/internal/service/shopee_escrow_detail.go`
- `go test ./...`
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bebad3cc48327ba5f00cf54b217dc