### PR TITLE
Add batch history status

### DIFF
--- a/backend/internal/handlers/dropship_handler.go
+++ b/backend/internal/handlers/dropship_handler.go
@@ -58,12 +58,21 @@ func (h *DropshipHandler) HandleImport(c *gin.Context) {
 	go func(fh *multipart.FileHeader, ch string, batchID int64) {
 		f, err := fh.Open()
 		if err != nil {
+			if h.batch != nil {
+				h.batch.UpdateStatus(context.Background(), batchID, "failed", err.Error())
+			}
 			return
 		}
 		defer f.Close()
-		h.svc.ImportFromCSV(context.Background(), f, ch)
+		if err := h.svc.ImportFromCSV(context.Background(), f, ch); err != nil {
+			if h.batch != nil {
+				h.batch.UpdateStatus(context.Background(), batchID, "failed", err.Error())
+			}
+			return
+		}
 		if h.batch != nil {
 			h.batch.UpdateDone(context.Background(), batchID, 1)
+			h.batch.UpdateStatus(context.Background(), batchID, "completed", "")
 		}
 	}(fileHeader, channel, id)
 

--- a/backend/internal/migrations/0060_add_batch_status.down.sql
+++ b/backend/internal/migrations/0060_add_batch_status.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE batch_history
+    DROP COLUMN IF EXISTS status,
+    DROP COLUMN IF EXISTS error_message;

--- a/backend/internal/migrations/0060_add_batch_status.up.sql
+++ b/backend/internal/migrations/0060_add_batch_status.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE batch_history
+    ADD COLUMN status TEXT NOT NULL DEFAULT 'processing',
+    ADD COLUMN error_message TEXT;

--- a/backend/internal/models/batch.go
+++ b/backend/internal/models/batch.go
@@ -6,4 +6,6 @@ type BatchHistory struct {
 	StartedAt   string `db:"started_at" json:"started_at"`
 	TotalData   int    `db:"total_data" json:"total_data"`
 	DoneData    int    `db:"done_data" json:"done_data"`
+	Status      string `db:"status" json:"status"`
+	ErrorMsg    string `db:"error_message" json:"error_message"`
 }

--- a/backend/internal/repository/batch_repo.go
+++ b/backend/internal/repository/batch_repo.go
@@ -13,8 +13,8 @@ type BatchRepo struct{ db DBTX }
 func NewBatchRepo(db DBTX) *BatchRepo { return &BatchRepo{db: db} }
 
 func (r *BatchRepo) Insert(ctx context.Context, b *models.BatchHistory) (int64, error) {
-	query := `INSERT INTO batch_history (process_type, started_at, total_data, done_data)
-              VALUES (:process_type, NOW(), :total_data, :done_data)
+	query := `INSERT INTO batch_history (process_type, started_at, total_data, done_data, status, error_message)
+              VALUES (:process_type, NOW(), :total_data, :done_data, :status, :error_message)
               RETURNING id`
 	rows, err := sqlx.NamedQueryContext(ctx, r.db, query, b)
 	if err != nil {
@@ -34,6 +34,13 @@ func (r *BatchRepo) Insert(ctx context.Context, b *models.BatchHistory) (int64, 
 func (r *BatchRepo) UpdateDone(ctx context.Context, id int64, done int) error {
 	_, err := r.db.ExecContext(ctx,
 		`UPDATE batch_history SET done_data=$2 WHERE id=$1`, id, done)
+	return err
+}
+
+func (r *BatchRepo) UpdateStatus(ctx context.Context, id int64, status, msg string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE batch_history SET status=$2, error_message=$3 WHERE id=$1`,
+		id, status, msg)
 	return err
 }
 

--- a/backend/internal/service/batch_service.go
+++ b/backend/internal/service/batch_service.go
@@ -20,6 +20,10 @@ func (s *BatchService) UpdateDone(ctx context.Context, id int64, done int) error
 	return s.repo.UpdateDone(ctx, id, done)
 }
 
+func (s *BatchService) UpdateStatus(ctx context.Context, id int64, status, msg string) error {
+	return s.repo.UpdateStatus(ctx, id, status, msg)
+}
+
 func (s *BatchService) List(ctx context.Context) ([]models.BatchHistory, error) {
 	return s.repo.List(ctx)
 }

--- a/frontend/dropship-erp-ui/src/components/BatchHistoryPage.tsx
+++ b/frontend/dropship-erp-ui/src/components/BatchHistoryPage.tsx
@@ -20,6 +20,8 @@ export default function BatchHistoryPage() {
     },
     { label: "Total", key: "total_data", align: "right" },
     { label: "Done", key: "done_data", align: "right" },
+    { label: "Status", key: "status" },
+    { label: "Error", key: "error_message" },
   ];
 
   return (

--- a/frontend/dropship-erp-ui/src/types/index.ts
+++ b/frontend/dropship-erp-ui/src/types/index.ts
@@ -590,6 +590,8 @@ export interface BatchHistory {
   started_at: string;
   total_data: number;
   done_data: number;
+  status: string;
+  error_message: string;
 }
 
 export interface DashboardData {


### PR DESCRIPTION
## Summary
- support `status` and `error_message` fields for batch import history
- update dropship import handler to mark batches completed or failed
- expose new batch status fields in API and UI
- create migration for new columns

## Testing
- `go test ./...`
- `npm test --silent` *(fails: Found multiple elements, etc.)*
- `npm run lint --silent` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68727adb0ea883278cc53fa0cf7a0848