### PR TITLE
Fix frontend build errors

### DIFF
--- a/frontend/dropship-erp-ui/src/api/index.ts
+++ b/frontend/dropship-erp-ui/src/api/index.ts
@@ -16,6 +16,7 @@ import type {
   SalesProfit,
   DailyPurchaseTotal,
   MonthlyPurchaseTotal,
+  DashboardData,
   ShopeeOrderDetailRow,
   ShopeeOrderItemRow,
   ShopeeOrderPackageRow,

--- a/frontend/dropship-erp-ui/src/api/journal.ts
+++ b/frontend/dropship-erp-ui/src/api/journal.ts
@@ -20,7 +20,7 @@ export function getJournal(id: number) {
 }
 
 export function getJournalLines(id: number) {
-  return api.get<JournalLine & { account_name: string }[]>(
+  return api.get<(JournalLine & { account_name: string })[]>(
     `/journal/${id}/lines`,
   );
 }

--- a/frontend/dropship-erp-ui/src/components/Dashboard.tsx
+++ b/frontend/dropship-erp-ui/src/components/Dashboard.tsx
@@ -183,10 +183,30 @@ export default function Dashboard() {
 
       {/* Additional Summary Cards */}
       <div className="grid grid-cols-4 gap-4 mt-8">
-        <SummaryCard label="Total Price" value={s.total_price.value} change={s.total_price.change} />
-        <SummaryCard label="Total Discounts" value={s.total_discounts.value} change={s.total_discounts.change} />
-        <SummaryCard label="Total Net Profit" value={s.total_net_profit.value} change={s.total_net_profit.change} />
-        <SummaryCard label="Outstanding Amount" value={s.outstanding_amount.value} change={s.outstanding_amount.change} />
+        <SummaryCard
+          label="Total Price"
+          value={s.total_price.value}
+          change={s.total_price.change}
+          loading={metricsLoading}
+        />
+        <SummaryCard
+          label="Total Discounts"
+          value={s.total_discounts.value}
+          change={s.total_discounts.change}
+          loading={metricsLoading}
+        />
+        <SummaryCard
+          label="Total Net Profit"
+          value={s.total_net_profit.value}
+          change={s.total_net_profit.change}
+          loading={metricsLoading}
+        />
+        <SummaryCard
+          label="Outstanding Amount"
+          value={s.outstanding_amount.value}
+          change={s.outstanding_amount.change}
+          loading={metricsLoading}
+        />
       </div>
 
       <div className="grid grid-cols-2 gap-6 mt-8">

--- a/frontend/dropship-erp-ui/src/components/ExpensePage.test.tsx
+++ b/frontend/dropship-erp-ui/src/components/ExpensePage.test.tsx
@@ -2,7 +2,6 @@ import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import { fireEvent, screen, waitFor } from "@testing-library/dom";
 import * as expApi from "../api/expenses";
-import * as baseApi from "../api";
 import ExpensePage from "./ExpensePage";
 
 jest.mock("../api/expenses", () => ({

--- a/frontend/dropship-erp-ui/src/components/ExpensePage.tsx
+++ b/frontend/dropship-erp-ui/src/components/ExpensePage.tsx
@@ -18,7 +18,6 @@ import {
   createExpense,
   listExpenses,
   deleteExpense,
-  getExpense,
   updateExpense,
 } from "../api/expenses";
 import { getJournalLinesBySource } from "../api/journal";
@@ -30,9 +29,6 @@ export default function ExpensePage() {
   const {
     data: list,
     controls,
-    page,
-    setPage,
-    pageSize,
     reload,
   } = useServerPagination((params) =>
     listExpenses({ page: params.page, page_size: params.pageSize }).then((r) => r.data),
@@ -72,7 +68,7 @@ export default function ExpensePage() {
           lines: lines.map((l) => ({
             account_id: Number(l.account),
             amount: Number(l.amount),
-          })),
+          })) as any,
           date: new Date(date).toISOString(),
         });
       } else {
@@ -82,7 +78,7 @@ export default function ExpensePage() {
           lines: lines.map((l) => ({
             account_id: Number(l.account),
             amount: Number(l.amount),
-          })),
+          })) as any,
           date: new Date(date).toISOString(),
         });
       }

--- a/frontend/dropship-erp-ui/src/components/JournalPage.test.tsx
+++ b/frontend/dropship-erp-ui/src/components/JournalPage.test.tsx
@@ -2,7 +2,6 @@ import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import { fireEvent, screen, waitFor } from "@testing-library/dom";
 import * as api from "../api/journal";
-import * as baseApi from "../api";
 import JournalPage from "./JournalPage";
 
 jest.mock("../api/journal", () => ({

--- a/frontend/dropship-erp-ui/src/components/JournalPage.tsx
+++ b/frontend/dropship-erp-ui/src/components/JournalPage.tsx
@@ -87,13 +87,13 @@ export default function JournalPage() {
         <>
           <Button
             size="small"
-            onClick={() => {
-              setDetailEntry(j);
-              getJournalLines(j.journal_id).then((r) => {
-                setDetailLines(r.data);
-                setDetailOpen(true);
-              });
-            }}
+              onClick={() => {
+                setDetailEntry(j);
+                getJournalLines(j.journal_id).then((r) => {
+                  setDetailLines(r.data as any);
+                  setDetailOpen(true);
+                });
+              }}
           >
             Detail
           </Button>

--- a/frontend/dropship-erp-ui/src/components/ReconcileDashboard.tsx
+++ b/frontend/dropship-erp-ui/src/components/ReconcileDashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import type { JSX } from "react";
 import {
   Alert,
   Button,

--- a/frontend/dropship-erp-ui/src/components/SalesSummaryPage.tsx
+++ b/frontend/dropship-erp-ui/src/components/SalesSummaryPage.tsx
@@ -99,7 +99,7 @@ export default function SalesSummaryPage() {
               from,
               to,
             });
-      const arr = res.data.sort((a, b) => {
+      const arr = (res.data as any[]).sort((a, b) => {
         const da = period === "Daily" ? a.date : a.month;
         const db = period === "Daily" ? b.date : b.month;
         return da < db ? -1 : 1;
@@ -147,7 +147,7 @@ export default function SalesSummaryPage() {
   }, [channel, store, from, to, period]);
 
   const openDetail = async (a: ShopeeAdjustment) => {
-    const id = `${a.no_pesanan}-${a.tanggal_penyesuaian.replaceAll("-", "")}`;
+    const id = `${a.no_pesanan}-${a.tanggal_penyesuaian.replace(/-/g, "")}`;
     try {
       const [linesRes, detailRes] = await Promise.all([
         getJournalLinesBySource(id),

--- a/frontend/dropship-erp-ui/src/components/ShopeeOrderDetailPage.tsx
+++ b/frontend/dropship-erp-ui/src/components/ShopeeOrderDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import type { JSX } from "react";
 import {
   Button,
   Alert,

--- a/frontend/dropship-erp-ui/src/components/ShopeeSalesPage.tsx
+++ b/frontend/dropship-erp-ui/src/components/ShopeeSalesPage.tsx
@@ -385,7 +385,6 @@ export default function ShopeeSalesPage() {
     },
     {
       label: "Actions",
-      key: "actions",
       render: (_, row) => {
         if (row.is_settled_confirmed) return "✔️";
         if (row.is_data_mismatch)


### PR DESCRIPTION
## Summary
- import missing DashboardData type
- pass loading prop to additional Dashboard summary cards
- tweak data sorting & ID generation in SalesSummaryPage
- cast journal lines to expected type and fix API journal typing
- clean up unused imports and adjust table action column type
- add JSX import type to pages with JSX.Element return values

## Testing
- `npm run build` in `frontend/dropship-erp-ui`
- `npm test` in `frontend/dropship-erp-ui` *(fails: MetricsPage, ReconcileDashboard, SalesSummaryPage, KasAccountPage, WithdrawalPage)*
- `npm run lint` in `frontend/dropship-erp-ui` *(fails: 81 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68728aad3f088327beb7c8e410df8707