### PR TITLE
Improve dashboard metric layout

### DIFF
--- a/frontend/dropship-erp-ui/src/components/Dashboard.tsx
+++ b/frontend/dropship-erp-ui/src/components/Dashboard.tsx
@@ -136,40 +136,38 @@ export default function Dashboard() {
 
 
       {/*
-        Parent container for the four summary cards. The flex row keeps cards
-        horizontally aligned with gaps, max width centers the row and
-        overflow-x-auto allows scrolling on small screens.
+        Parent container for the summary cards. Using a responsive grid keeps
+        the metrics aligned consistently across pages and matches the layout on
+        the Balance Sheet page.
       */}
-      <>
-        {metrics && (
-          <div className="inline-flex gap-x-4 max-w-screen-lg mx-auto w-full overflow-x-auto px-4 scrollbar-thin shrink-0">
-            <SummaryCard
-              label="TOTAL ORDERS"
-              value={metrics.total_orders?.value}
-              change={metrics.total_orders?.change}
-              loading={metricsLoading}
-            />
-            <SummaryCard
-              label="AVERAGE ORDER VALUE"
-              value={metrics.avg_order_value?.value}
-              change={metrics.avg_order_value?.change}
-              loading={metricsLoading}
-            />
-            <SummaryCard
-              label="TOTAL CANCELLED ORDERS"
-              value={metrics.total_cancelled?.value}
-              change={metrics.total_cancelled?.change}
-              loading={metricsLoading}
-            />
-            <SummaryCard
-              label="TOTAL CUSTOMERS"
-              value={metrics.total_customers?.value}
-              change={metrics.total_customers?.change}
-              loading={metricsLoading}
-            />
-          </div>
-        )}
-      </>
+      {metrics && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-w-screen-lg mx-auto w-full px-4">
+          <SummaryCard
+            label="TOTAL ORDERS"
+            value={metrics.total_orders?.value}
+            change={metrics.total_orders?.change}
+            loading={metricsLoading}
+          />
+          <SummaryCard
+            label="AVERAGE ORDER VALUE"
+            value={metrics.avg_order_value?.value}
+            change={metrics.avg_order_value?.change}
+            loading={metricsLoading}
+          />
+          <SummaryCard
+            label="TOTAL CANCELLED ORDERS"
+            value={metrics.total_cancelled?.value}
+            change={metrics.total_cancelled?.change}
+            loading={metricsLoading}
+          />
+          <SummaryCard
+            label="TOTAL CUSTOMERS"
+            value={metrics.total_customers?.value}
+            change={metrics.total_customers?.change}
+            loading={metricsLoading}
+          />
+        </div>
+      )}
       {/* Charts */}
       <div className="grid grid-cols-2 gap-6 mt-8">
         <div className="bg-white rounded-xl shadow p-4 h-64">


### PR DESCRIPTION
## Summary
- align dashboard metric cards with a responsive grid layout

## Testing
- `npm run lint` *(fails: Unexpected any in many files)*
- `npm test --silent` *(fails: 5 failed, 16 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687298385f9c832780b31c4b9d9cc93c