### PR TITLE
Refactor dashboard styles

### DIFF
--- a/frontend/dropship-erp-ui/src/components/Dashboard.tsx
+++ b/frontend/dropship-erp-ui/src/components/Dashboard.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from "recharts";
 import { fetchDashboard } from "../api";
-import type { DashboardData } from "../types";
+import type { DashboardData, DashboardMetrics } from "../types";
+import SummaryCard from "./SummaryCard";
 
 // Dashboard component showing summary cards and charts
 export default function Dashboard() {
@@ -15,119 +16,94 @@ export default function Dashboard() {
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      try {
-        const res = await fetchDashboard({
-          order: orderType,
-          channel,
-          store,
-          period,
-          month,
-          year,
-        });
-        setData(res.data);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchData();
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetchDashboard({
+        order: orderType,
+        channel,
+        store,
+        period,
+        month,
+        year,
+      });
+      setData(res.data);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("dashboard fetch", err);
+    } finally {
+      setLoading(false);
+    }
   }, [orderType, channel, store, period, month, year]);
 
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
   // metrics row should render even while loading, so do not early return
-
-  // Card component for each metrics. It receives backend values and the global
-  // loading state so we can render skeletons while data is being fetched.
-  const SummaryCard = ({
-    label,
-    value,
-    change,
-    loading: cardLoading,
-  }: {
-    label: string;
-    value?: number;
-    change?: number;
-    loading: boolean;
-  }) => (
-    <div
-      className="bg-white rounded-xl shadow p-6 flex flex-col min-w-[180px]"
-      aria-label={`${label} card`}
-    >
-      {/* metric label text */}
-      <div className="text-xs font-semibold text-gray-400 uppercase mb-2">
-        {label}
-      </div>
-      {cardLoading || value === undefined || value === null ? (
-        // Skeletons shown while loading data
-        <>
-          <div className="bg-gray-200 rounded w-16 h-6 animate-pulse mb-2" />
-          <div className="bg-gray-200 rounded w-16 h-6 animate-pulse mt-2" />
-        </>
-      ) : (
-        <>
-          {/* numeric value from backend */}
-          <div className="text-2xl font-bold text-gray-900">
-            {value.toLocaleString()}
-          </div>
-          {/* percent change indicator with arrow and color logic */}
-          <div className="mt-2 flex flex-row items-center text-start">
-            {change && change > 0 && (
-              <span className="text-green-600 mr-1">▲</span>
-            )}
-            {change && change < 0 && (
-              <span className="text-red-600 mr-1">▼</span>
-            )}
-            {typeof change === "number" && change !== 0 ? (
-              <span className={change > 0 ? "text-green-600" : "text-red-600"}>
-                {Math.abs(change * 100).toFixed(1)}%
-              </span>
-            ) : (
-              <span className="text-gray-400">—</span>
-            )}
-          </div>
-        </>
-      )}
-    </div>
-  );
-
-  // metrics values from backend; fallback to empty object when loading
   // metrics values returned from the backend dashboard endpoint
   const charts = data?.charts || {};
-  // `summary` contains the metric numbers we need. Cast to any to avoid
-  // extensive type declarations while still supporting loading state.
-  const metrics = (data?.summary as any) || {};
+  // typed metrics object for summary numbers
+  const metrics: DashboardMetrics = data?.summary || {};
   // global flag for metrics loading state
   const metricsLoading = loading || !data;
 
   return (
-    <div className="p-4 bg-gray-50 min-h-screen">
+    <div
+      style={{ padding: "1rem", backgroundColor: "#f9fafb", minHeight: "100vh" }}
+    >
       {/* Filter Controls */}
-      <div className="flex gap-2">
-        <select className="border p-1" value={orderType} onChange={(e) => setOrderType(e.target.value)}>
+      <div
+        style={{ display: "flex", gap: "0.5rem" }}
+      >
+        <select
+          style={{ border: "1px solid #ccc", padding: "0.25rem" }}
+          value={orderType}
+          onChange={(e) => setOrderType(e.target.value)}
+        >
           <option value="">All Orders</option>
           <option value="COD">COD</option>
         </select>
-        <select className="border p-1" value={channel} onChange={(e) => setChannel(e.target.value)}>
+        <select
+          style={{ border: "1px solid #ccc", padding: "0.25rem" }}
+          value={channel}
+          onChange={(e) => setChannel(e.target.value)}
+        >
           <option value="">All Channels</option>
           <option value="Shopee">Shopee</option>
         </select>
-        <select className="border p-1" value={store} onChange={(e) => setStore(e.target.value)}>
+        <select
+          style={{ border: "1px solid #ccc", padding: "0.25rem" }}
+          value={store}
+          onChange={(e) => setStore(e.target.value)}
+        >
           <option value="">All Stores</option>
           <option value="StoreA">StoreA</option>
         </select>
-        <select className="border p-1" value={period} onChange={(e) => setPeriod(e.target.value as any)}>
+        <select
+          style={{ border: "1px solid #ccc", padding: "0.25rem" }}
+          value={period}
+          onChange={(e) => setPeriod(e.target.value as any)}
+        >
           <option value="Monthly">Monthly</option>
           <option value="Yearly">Yearly</option>
         </select>
         {period === "Monthly" && (
-          <select className="border p-1" value={month} onChange={(e) => setMonth(Number(e.target.value))}>
+          <select
+            style={{ border: "1px solid #ccc", padding: "0.25rem" }}
+            value={month}
+            onChange={(e) => setMonth(Number(e.target.value))}
+          >
             {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => (
               <option key={m} value={m}>{m}</option>
             ))}
           </select>
         )}
-        <select className="border p-1" value={year} onChange={(e) => setYear(Number(e.target.value))}>
+        <select
+          style={{ border: "1px solid #ccc", padding: "0.25rem" }}
+          value={year}
+          onChange={(e) => setYear(Number(e.target.value))}
+        >
           {Array.from({ length: 3 }, (_, i) => now.getFullYear() - i).map((y) => (
             <option key={y} value={y}>{y}</option>
           ))}
@@ -170,8 +146,26 @@ export default function Dashboard() {
       )}
       {/* Charts */}
       <div style={{ marginTop: "1rem", display: "flex", gap: "1rem" }}>
-        <div className="bg-white rounded-xl shadow p-4 h-64">
-          <h3 className="text-sm uppercase text-gray-400 mb-1">Total Sales</h3>
+        <div
+          style={{
+            backgroundColor: "#fff",
+            borderRadius: "0.75rem",
+            boxShadow:
+              "0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px 0 rgba(0,0,0,0.06)",
+            padding: "1rem",
+            height: "16rem",
+          }}
+        >
+          <h3
+            style={{
+              fontSize: "0.875rem",
+              textTransform: "uppercase",
+              color: "#9ca3af",
+              marginBottom: "0.25rem",
+            }}
+          >
+            Total Sales
+          </h3>
           <LineChart width={700} height={200} data={charts.total_sales}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="date" />
@@ -180,8 +174,26 @@ export default function Dashboard() {
             <Line type="monotone" dataKey="value" stroke="#8884d8" />
           </LineChart>
         </div>
-        <div className="bg-white rounded-xl shadow p-4 h-64">
-          <h3 className="text-sm uppercase text-gray-400 mb-1">Average Order Value</h3>
+        <div
+          style={{
+            backgroundColor: "#fff",
+            borderRadius: "0.75rem",
+            boxShadow:
+              "0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px 0 rgba(0,0,0,0.06)",
+            padding: "1rem",
+            height: "16rem",
+          }}
+        >
+          <h3
+            style={{
+              fontSize: "0.875rem",
+              textTransform: "uppercase",
+              color: "#9ca3af",
+              marginBottom: "0.25rem",
+            }}
+          >
+            Average Order Value
+          </h3>
           <LineChart width={700} height={200} data={charts.avg_order_value}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="date" />
@@ -220,9 +232,34 @@ export default function Dashboard() {
         />
       </div>
 
-      <div className="grid grid-cols-2 gap-6 mt-8">
-        <div className="bg-white rounded-xl shadow p-4 h-64">
-          <h3 className="text-sm uppercase text-gray-400 mb-1">Number of Orders</h3>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+          gap: "1.5rem",
+          marginTop: "2rem",
+        }}
+      >
+        <div
+          style={{
+            backgroundColor: "#fff",
+            borderRadius: "0.75rem",
+            boxShadow:
+              "0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px 0 rgba(0,0,0,0.06)",
+            padding: "1rem",
+            height: "16rem",
+          }}
+        >
+          <h3
+            style={{
+              fontSize: "0.875rem",
+              textTransform: "uppercase",
+              color: "#9ca3af",
+              marginBottom: "0.25rem",
+            }}
+          >
+            Number of Orders
+          </h3>
           <LineChart width={1400} height={200} data={charts.number_of_orders}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="date" />

--- a/frontend/dropship-erp-ui/src/components/SummaryCard.tsx
+++ b/frontend/dropship-erp-ui/src/components/SummaryCard.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+
+export interface SummaryCardProps {
+  label: string;
+  value?: number;
+  change?: number;
+  loading: boolean;
+}
+
+export default function SummaryCard({
+  label,
+  value,
+  change,
+  loading,
+}: SummaryCardProps) {
+  return (
+    <div
+      style={{
+        backgroundColor: "#fff",
+        borderRadius: "0.75rem",
+        boxShadow: "0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px 0 rgba(0,0,0,0.06)",
+        padding: "1.5rem",
+        display: "flex",
+        flexDirection: "column",
+        minWidth: "180px",
+      }}
+      aria-label={`${label} card`}
+    >
+      <div
+        style={{
+          fontSize: "0.75rem",
+          fontWeight: 600,
+          color: "#9ca3af",
+          textTransform: "uppercase",
+          marginBottom: "0.5rem",
+        }}
+      >
+        {label}
+      </div>
+      {loading || value === undefined || value === null ? (
+        <>
+          <div
+            style={{
+              backgroundColor: "#e5e7eb",
+              borderRadius: "0.25rem",
+              width: "4rem",
+              height: "1.5rem",
+              animation: "pulse 2s cubic-bezier(0.4,0,0.6,1) infinite",
+              marginBottom: "0.5rem",
+            }}
+          />
+          <div
+            style={{
+              backgroundColor: "#e5e7eb",
+              borderRadius: "0.25rem",
+              width: "4rem",
+              height: "1.5rem",
+              animation: "pulse 2s cubic-bezier(0.4,0,0.6,1) infinite",
+              marginTop: "0.5rem",
+            }}
+          />
+        </>
+      ) : (
+        <>
+          <div
+            style={{
+              fontSize: "1.5rem",
+              fontWeight: 700,
+              color: "#111827",
+            }}
+          >
+            {value.toLocaleString()}
+          </div>
+          <div
+            style={{
+              marginTop: "0.5rem",
+              display: "flex",
+              flexDirection: "row",
+              alignItems: "center",
+              textAlign: "start",
+            }}
+          >
+            {change && change > 0 && (
+              <span style={{ color: "#16a34a", marginRight: "0.25rem" }}>▲</span>
+            )}
+            {change && change < 0 && (
+              <span style={{ color: "#dc2626", marginRight: "0.25rem" }}>▼</span>
+            )}
+            {typeof change === "number" && change !== 0 ? (
+              <span style={{ color: change > 0 ? "#16a34a" : "#dc2626" }}>
+                {Math.abs(change * 100).toFixed(1)}%
+              </span>
+            ) : (
+              <span style={{ color: "#9ca3af" }}>—</span>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/dropship-erp-ui/src/index.css
+++ b/frontend/dropship-erp-ui/src/index.css
@@ -6,3 +6,12 @@
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
 }
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: .5;
+  }
+}

--- a/frontend/dropship-erp-ui/src/types/index.ts
+++ b/frontend/dropship-erp-ui/src/types/index.ts
@@ -595,6 +595,23 @@ export interface BatchHistory {
 }
 
 export interface DashboardData {
-  summary: Record<string, { value: number; change: number }>;
+  summary: DashboardMetrics;
   charts: Record<string, { date: string; value: number }[]>;
+}
+
+export interface DashboardMetric {
+  value: number;
+  change: number;
+}
+
+export interface DashboardMetrics {
+  total_orders?: DashboardMetric;
+  avg_order_value?: DashboardMetric;
+  total_cancelled?: DashboardMetric;
+  total_customers?: DashboardMetric;
+  total_price?: DashboardMetric;
+  total_discounts?: DashboardMetric;
+  total_net_profit?: DashboardMetric;
+  outstanding_amount?: DashboardMetric;
+  [key: string]: DashboardMetric | undefined;
 }


### PR DESCRIPTION
## Summary
- convert Dashboard to inline styles
- add SummaryCard component
- add types for dashboard metrics
- expose pulse keyframes

## Testing
- `npm run lint` *(fails: 80 errors, 4 warnings)*
- `npm test` *(fails: 9 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6872a0e858fc8327843c969f9bd0b0bc