### PR TITLE
Add configurable concurrency limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ with environment variables. On startup the application runs database migrations
 automatically.
 Application logs are written to the directory specified by `logging.dir` in the
 config file. A new file named `YYYY-MM-DD.log` is created each day.
+Batch operations that fetch Shopee data in parallel respect the `max_threads`
+setting which limits how many goroutines run concurrently (defaults to `5`).
 
 Shopee API calls require credentials including a long-lived `refresh_token`.
 `ShopeeClient` refreshes the short-lived access token when it has expired rather

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -54,6 +54,7 @@ func main() {
 		repo.ChannelRepo,
 		repo.OrderDetailRepo,
 		shClient,
+		cfg.MaxThreads,
 	)
 	shopeeSvc := service.NewShopeeService(repo.DB, repo.ShopeeRepo, repo.DropshipRepo, repo.JournalRepo, repo.ShopeeAdjustmentRepo)
 	batchSvc := service.NewBatchService(repo.BatchRepo)
@@ -65,6 +66,7 @@ func main() {
 		repo.ShopeeAdjustmentRepo,
 		shClient,
 		batchSvc,
+		cfg.MaxThreads,
 	)
 	metricSvc := service.NewMetricService(
 		repo.DropshipRepo, repo.ShopeeRepo, repo.JournalRepo, repo.MetricRepo,

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -9,6 +9,9 @@ server:
 logging:
   dir: "logs"
 
+# Maximum number of concurrent threads used by batch processes
+max_threads: 5
+
 database:
   url: "postgres://erp_user:erp_pass@localhost:5432/dropship_erp?sslmode=disable"
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -16,11 +16,12 @@ import (
 
 // Config holds all application configuration values.
 type Config struct {
-	Server   ServerConfig
-	Database DatabaseConfig
-	JWT      JWTConfig
-	Shopee   ShopeeAPIConfig `mapstructure:"shopee_api"`
-	Logging  LoggingConfig
+	Server     ServerConfig
+	Database   DatabaseConfig
+	JWT        JWTConfig
+	Shopee     ShopeeAPIConfig `mapstructure:"shopee_api"`
+	Logging    LoggingConfig
+	MaxThreads int `mapstructure:"max_threads"`
 }
 
 // ServerConfig contains HTTP server settings.
@@ -74,6 +75,7 @@ func LoadConfig() (*Config, error) {
 	// Default CORS origin for local development
 	viper.SetDefault("server.cors_origins", []string{"http://localhost:5173"})
 	viper.SetDefault("logging.dir", "logs")
+	viper.SetDefault("max_threads", 5)
 
 	// Read from config.yaml
 	if err := viper.ReadInConfig(); err != nil {
@@ -89,6 +91,10 @@ func LoadConfig() (*Config, error) {
 	// Handle slice parsing from env vars
 	cfg.Server.CorsOrigins = viper.GetStringSlice("server.cors_origins")
 	cfg.Logging.Dir = viper.GetString("logging.dir")
+	cfg.MaxThreads = viper.GetInt("max_threads")
+	if cfg.MaxThreads <= 0 {
+		cfg.MaxThreads = 5
+	}
 
 	// Validate required fields
 	if cfg.Database.URL == "" {

--- a/backend/internal/service/dropship_service_test.go
+++ b/backend/internal/service/dropship_service_test.go
@@ -190,7 +190,7 @@ func TestImportFromCSV_Success(t *testing.T) {
 	fake := &fakeDropshipRepo{}
 	jfake := &fakeJournalRepoDrop{}
 	srepo := &fakeStoreRepo{store: store}
-	svc := NewDropshipService(nil, fake, jfake, srepo, nil, client)
+	svc := NewDropshipService(nil, fake, jfake, srepo, nil, client, 5)
 
 	ctx := context.Background()
 	count, err := svc.ImportFromCSV(ctx, &buf, "")
@@ -226,7 +226,7 @@ func TestImportFromCSV_ParseError(t *testing.T) {
 	w.Flush()
 
 	fake := &fakeDropshipRepo{}
-	svc := NewDropshipService(nil, fake, nil, nil, nil, nil)
+	svc := NewDropshipService(nil, fake, nil, nil, nil, nil, 5)
 	count, err := svc.ImportFromCSV(context.Background(), &buf, "")
 	if err == nil {
 		t.Fatal("expected parse error, got nil")
@@ -250,7 +250,7 @@ func TestImportFromCSV_SkipExisting(t *testing.T) {
 	w.Flush()
 
 	fake := &fakeDropshipRepo{existing: map[string]bool{"PS-EXIST": true}}
-	svc := NewDropshipService(nil, fake, nil, nil, nil, nil)
+	svc := NewDropshipService(nil, fake, nil, nil, nil, nil, 5)
 	count, err := svc.ImportFromCSV(context.Background(), &buf, "")
 	if err != nil {
 		t.Fatalf("ImportFromCSV error: %v", err)
@@ -304,7 +304,7 @@ func TestImportFromCSV_JournalSumsProducts(t *testing.T) {
 	fake := &fakeDropshipRepo{}
 	jfake := &fakeJournalRepoDrop{}
 	srepo := &fakeStoreRepo{store: store}
-	svc := NewDropshipService(nil, fake, jfake, srepo, nil, client)
+	svc := NewDropshipService(nil, fake, jfake, srepo, nil, client, 5)
 
 	count, err := svc.ImportFromCSV(context.Background(), &buf, "")
 	if err != nil {
@@ -344,7 +344,7 @@ func TestImportFromCSV_ChannelFilter(t *testing.T) {
 	w.Flush()
 
 	fake := &fakeDropshipRepo{}
-	svc := NewDropshipService(nil, fake, nil, nil, nil, nil)
+	svc := NewDropshipService(nil, fake, nil, nil, nil, nil, 5)
 
 	count, err := svc.ImportFromCSV(context.Background(), &buf, "Tokopedia")
 	if err != nil {
@@ -397,7 +397,7 @@ func TestImportFromCSV_SkipOnDetailError(t *testing.T) {
 
 	fakeRepo := &fakeDropshipRepo{}
 	srepo := &fakeStoreRepo{store: store}
-	svc := NewDropshipService(nil, fakeRepo, nil, srepo, nil, client)
+	svc := NewDropshipService(nil, fakeRepo, nil, srepo, nil, client, 5)
 
 	count, err := svc.ImportFromCSV(context.Background(), &buf, "")
 	if err != nil {

--- a/backend/internal/service/reconcile_service_batch_test.go
+++ b/backend/internal/service/reconcile_service_batch_test.go
@@ -120,7 +120,7 @@ func TestProcessShopeeStatusBatch_Escrow(t *testing.T) {
 	client := NewShopeeClient(config.ShopeeAPIConfig{BaseURLShopee: srv.URL, PartnerID: "1", PartnerKey: "key"})
 	client.httpClient = srv.Client()
 
-	svc := NewReconcileService(nil, drop, nil, jrepo, nil, srepo, nil, nil, client, nil)
+	svc := NewReconcileService(nil, drop, nil, jrepo, nil, srepo, nil, nil, client, nil, 5)
 
 	svc.processShopeeStatusBatch(context.Background(), "ShopA", []*models.DropshipPurchase{dp1, dp2})
 
@@ -167,7 +167,7 @@ func TestUpdateShopeeStatuses_BatchHistory(t *testing.T) {
 	client := NewShopeeClient(config.ShopeeAPIConfig{BaseURLShopee: srv.URL, PartnerID: "1", PartnerKey: "key"})
 	client.httpClient = srv.Client()
 
-	svc := NewReconcileService(nil, drop, nil, jrepo, nil, srepo, nil, nil, client, batchSvc)
+	svc := NewReconcileService(nil, drop, nil, jrepo, nil, srepo, nil, nil, client, batchSvc, 5)
 
 	svc.UpdateShopeeStatuses(context.Background(), []string{"INV1"})
 

--- a/backend/internal/service/reconcile_service_test.go
+++ b/backend/internal/service/reconcile_service_test.go
@@ -130,7 +130,7 @@ func TestMatchAndJournal_Success(t *testing.T) {
 	fRec := &fakeRecRepoRec{}
 	fDetail := &fakeDetailRepo{}
 
-	svc := NewReconcileService(nil, fDrop, fShopee, fJournal, fRec, nil, fDetail, nil, nil, nil)
+	svc := NewReconcileService(nil, fDrop, fShopee, fJournal, fRec, nil, fDetail, nil, nil, nil, 5)
 	err := svc.MatchAndJournal(ctx, "DP-111", "SO-222", "ShopA")
 	if err != nil {
 		t.Fatalf("MatchAndJournal error: %v", err)


### PR DESCRIPTION
## Summary
- support `max_threads` configuration with default 5
- respect `max_threads` in dropship and reconcile services
- update tests and docs for new config

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68734ace6f348327a3b8d60ce722f418