### PR TITLE
Update sales profit calc for shipping discount

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ Discrepancy* adjustment when they differ.
 - Shopee reconciliation batches run in parallel for faster processing.
 - Automatically compute revenue, COGS, fees and net profit metrics.
  - Sales Profit page shows discounts and links to all related journal entries.
-   Adjustments including shipping fee discrepancies are now factored into profit
-   calculations.
+   Shipping discounts (account `5.5.0.6`) and escrow journals are included when
+   calculating profit. Adjustments including shipping fee discrepancies are also
+   factored into profit calculations.
 - View general ledger, balance sheet and profit and loss pages.
 - Manage channels, accounts and expenses. Expenses can be edited with a selectable date and the previous journal is reversed automatically.
 - Sales Summary dashboard now shows cancelled order count and total Biaya Mitra posted for those cancellations.

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -276,6 +276,8 @@ type SalesProfit struct {
 	BiayaAdministrasi float64   `db:"biaya_administrasi" json:"biaya_administrasi"`
 	BiayaLayanan      float64   `db:"biaya_layanan" json:"biaya_layanan"`
 	BiayaVoucher      float64   `db:"biaya_voucher" json:"biaya_voucher"`
+	BiayaTransaksi    float64   `db:"biaya_transaksi" json:"biaya_transaksi"`
+	DiskonOngkir      float64   `db:"diskon_ongkir" json:"diskon_ongkir"`
 	BiayaAffiliate    float64   `db:"biaya_affiliate" json:"biaya_affiliate"`
 	BiayaRefund       float64   `db:"biaya_refund" json:"biaya_refund"`
 	SelisihOngkir     float64   `db:"selisih_ongkir" json:"selisih_ongkir"`

--- a/backend/internal/repository/shopee_repo.go
+++ b/backend/internal/repository/shopee_repo.go
@@ -432,6 +432,7 @@ func (r *ShopeeRepo) ListSalesProfit(
                SUM(CASE WHEN jl.account_id = 52004 THEN jl.amount ELSE 0 END) AS biaya_layanan,
                SUM(CASE WHEN jl.account_id = 52011 THEN jl.amount ELSE 0 END) AS biaya_transaksi,
                SUM(CASE WHEN jl.account_id = 55001 THEN jl.amount ELSE 0 END) AS biaya_voucher,
+               SUM(CASE WHEN jl.account_id = 55006 THEN jl.amount ELSE 0 END) AS diskon_ongkir,
                SUM(CASE WHEN jl.account_id = 55002 THEN jl.amount ELSE 0 END) + COALESCE(aff.aff,0) AS biaya_affiliate,
                COALESCE(adj.refund,0) AS biaya_refund,
                COALESCE(adj.selisih,0) AS selisih_ongkir,
@@ -444,6 +445,7 @@ func (r *ShopeeRepo) ListSalesProfit(
                    + SUM(CASE WHEN jl.account_id = 52004 THEN jl.amount ELSE 0 END)
                    + SUM(CASE WHEN jl.account_id = 52011 THEN jl.amount ELSE 0 END)
                    + SUM(CASE WHEN jl.account_id = 55001 THEN jl.amount ELSE 0 END)
+                   + SUM(CASE WHEN jl.account_id = 55006 THEN jl.amount ELSE 0 END)
                    + SUM(CASE WHEN jl.account_id = 55002 THEN jl.amount ELSE 0 END)
                    + COALESCE(adj.refund,0)
                    + COALESCE(adj.selisih,0)
@@ -457,6 +459,7 @@ func (r *ShopeeRepo) ListSalesProfit(
                            + SUM(CASE WHEN jl.account_id = 52004 THEN jl.amount ELSE 0 END)
                            + SUM(CASE WHEN jl.account_id = 52011 THEN jl.amount ELSE 0 END)
                            + SUM(CASE WHEN jl.account_id = 55001 THEN jl.amount ELSE 0 END)
+                           + SUM(CASE WHEN jl.account_id = 55006 THEN jl.amount ELSE 0 END)
                            + SUM(CASE WHEN jl.account_id = 55002 THEN jl.amount ELSE 0 END)
                            + COALESCE(adj.refund,0)
                            + COALESCE(adj.selisih,0)
@@ -492,8 +495,8 @@ func (r *ShopeeRepo) ListSalesProfit(
               ) adj ON adj.kode_pesanan = je.source_id
               JOIN stores st ON dp.nama_toko = st.nama_toko
                JOIN jenis_channels jc ON st.jenis_channel_id = jc.jenis_channel_id
-               JOIN shopee_settled ss ON ss.no_pesanan = je.source_id AND ss.is_settled_confirmed = TRUE
-               WHERE je.source_type IN ('pending_sales','shopee_settled')`
+              LEFT JOIN shopee_settled ss ON ss.no_pesanan = je.source_id AND ss.is_settled_confirmed = TRUE
+               WHERE je.source_type IN ('pending_sales','shopee_settled','shopee_escrow')`
 	args := []interface{}{}
 	conds := []string{}
 	arg := 1
@@ -541,6 +544,8 @@ func (r *ShopeeRepo) ListSalesProfit(
 		"biaya_administrasi":  "biaya_administrasi",
 		"biaya_layanan":       "biaya_layanan",
 		"biaya_voucher":       "biaya_voucher",
+		"biaya_transaksi":     "biaya_transaksi",
+		"diskon_ongkir":       "diskon_ongkir",
 		"biaya_affiliate":     "biaya_affiliate",
 		"biaya_refund":        "biaya_refund",
 		"selisih_ongkir":      "selisih_ongkir",
@@ -567,6 +572,8 @@ func (r *ShopeeRepo) ListSalesProfit(
 		BiayaAdministrasi float64   `db:"biaya_administrasi"`
 		BiayaLayanan      float64   `db:"biaya_layanan"`
 		BiayaVoucher      float64   `db:"biaya_voucher"`
+		BiayaTransaksi    float64   `db:"biaya_transaksi"`
+		DiskonOngkir      float64   `db:"diskon_ongkir"`
 		BiayaAffiliate    float64   `db:"biaya_affiliate"`
 		BiayaRefund       float64   `db:"biaya_refund"`
 		SelisihOngkir     float64   `db:"selisih_ongkir"`
@@ -589,6 +596,8 @@ func (r *ShopeeRepo) ListSalesProfit(
 			BiayaAdministrasi: r.BiayaAdministrasi,
 			BiayaLayanan:      r.BiayaLayanan,
 			BiayaVoucher:      r.BiayaVoucher,
+			BiayaTransaksi:    r.BiayaTransaksi,
+			DiskonOngkir:      r.DiskonOngkir,
 			BiayaAffiliate:    r.BiayaAffiliate,
 			BiayaRefund:       r.BiayaRefund,
 			SelisihOngkir:     r.SelisihOngkir,

--- a/backend/internal/service/shopee_service.go
+++ b/backend/internal/service/shopee_service.go
@@ -671,7 +671,7 @@ func (s *ShopeeService) ListSalesProfit(
 	for i := range list {
 		p := list[i]
 		revenue := p.AmountSales + p.AdjustmentIncome
-		cost := p.ModalPurchase + p.BiayaMitraJakmall + p.BiayaAdministrasi + p.BiayaLayanan + p.BiayaVoucher + p.BiayaAffiliate + p.BiayaRefund + p.SelisihOngkir + p.Discount
+		cost := p.ModalPurchase + p.BiayaMitraJakmall + p.BiayaAdministrasi + p.BiayaLayanan + p.BiayaVoucher + p.BiayaTransaksi + p.DiskonOngkir + p.BiayaAffiliate + p.BiayaRefund + p.SelisihOngkir + p.Discount
 		profit := revenue - cost
 		list[i].Profit = profit
 		if revenue == 0 {

--- a/frontend/dropship-erp-ui/src/components/SalesProfitPage.tsx
+++ b/frontend/dropship-erp-ui/src/components/SalesProfitPage.tsx
@@ -116,6 +116,12 @@ export default function SalesProfitPage() {
       render: money,
     },
     {
+      label: "Diskon Ongkir",
+      key: "diskon_ongkir",
+      align: "right",
+      render: money,
+    },
+    {
       label: "Biaya Affiliate",
       key: "biaya_affiliate",
       align: "right",

--- a/frontend/dropship-erp-ui/src/types/index.ts
+++ b/frontend/dropship-erp-ui/src/types/index.ts
@@ -439,6 +439,8 @@ export interface SalesProfit {
   biaya_administrasi: number;
   biaya_layanan: number;
   biaya_voucher: number;
+  biaya_transaksi: number;
+  diskon_ongkir: number;
   biaya_affiliate: number;
   biaya_refund: number;
   selisih_ongkir: number;


### PR DESCRIPTION
## Summary
- include `diskon_ongkir` and `biaya_transaksi` in sales profit backend query and struct
- compute profit with transaction fees and shipping discounts
- update README with shipping discount details

## Testing
- `go test ./...`
- `npm test` *(fails: some tests do not pass)*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68735ffc1abc83278793c0758345d1d8