### PR TITLE
Handle duplicate journals and record batch import details

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Discrepancy* adjustment when they differ.
 - A dedicated `PPh Final UMKM` account (`5.4.1`) tracks these tax expenses.
 - View Shopee wallet transactions by store on the **Wallet Transactions** page;
   pagination now uses a **More** button with filter dropdowns.
+- View batch import history on the **Batch History** page with a button to see
+  transaction-level results.
 
 Configuration is read from `backend/config.yaml` and values can be overridden
 with environment variables. On startup the application runs database migrations

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -47,17 +47,18 @@ func main() {
 
 	// 3) Initialize services with the appropriate repo interfaces
 	shClient := service.NewShopeeClient(cfg.Shopee)
+	batchSvc := service.NewBatchService(repo.BatchRepo, repo.BatchDetailRepo)
 	dropshipSvc := service.NewDropshipService(
 		repo.DB,
 		repo.DropshipRepo,
 		repo.JournalRepo,
 		repo.ChannelRepo,
 		repo.OrderDetailRepo,
+		batchSvc,
 		shClient,
 		cfg.MaxThreads,
 	)
 	shopeeSvc := service.NewShopeeService(repo.DB, repo.ShopeeRepo, repo.DropshipRepo, repo.JournalRepo, repo.ShopeeAdjustmentRepo)
-	batchSvc := service.NewBatchService(repo.BatchRepo)
 	reconSvc := service.NewReconcileService(
 		repo.DB,
 		repo.DropshipRepo, repo.ShopeeRepo, repo.JournalRepo, repo.ReconcileRepo,

--- a/backend/internal/handlers/batch_handler.go
+++ b/backend/internal/handlers/batch_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/ramadhan22/dropship-erp/backend/internal/service"
@@ -16,10 +17,26 @@ func NewBatchHandler(s *service.BatchService) *BatchHandler { return &BatchHandl
 func (h *BatchHandler) RegisterRoutes(r gin.IRouter) {
 	grp := r.Group("/batches")
 	grp.GET("/", h.list)
+	grp.GET("/:id/details", h.details)
 }
 
 func (h *BatchHandler) list(c *gin.Context) {
 	list, err := h.svc.List(context.Background())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, list)
+}
+
+func (h *BatchHandler) details(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	list, err := h.svc.ListDetails(context.Background(), id)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/handlers/dropship_handler.go
+++ b/backend/internal/handlers/dropship_handler.go
@@ -16,7 +16,7 @@ import (
 
 // DropshipServiceInterface defines only the method the handler needs.
 type DropshipServiceInterface interface {
-	ImportFromCSV(ctx context.Context, r io.Reader, channel string) (int, error)
+	ImportFromCSV(ctx context.Context, r io.Reader, channel string, batchID int64) (int, error)
 	ListDropshipPurchases(ctx context.Context, channel, store, from, to, orderNo, sortBy, dir string, limit, offset int) ([]models.DropshipPurchase, int, error)
 	SumDropshipPurchases(ctx context.Context, channel, store, from, to string) (float64, error)
 	GetDropshipPurchaseByID(ctx context.Context, kodePesanan string) (*models.DropshipPurchase, error)
@@ -78,7 +78,7 @@ func (h *DropshipHandler) HandleImport(c *gin.Context) {
 			return
 		}
 		defer f.Close()
-		count, err := h.svc.ImportFromCSV(context.Background(), f, ch)
+		count, err := h.svc.ImportFromCSV(context.Background(), f, ch, batchID)
 		if err != nil {
 			if h.batch != nil {
 				h.batch.UpdateStatus(context.Background(), batchID, "failed", err.Error())

--- a/backend/internal/handlers/dropship_handler_test.go
+++ b/backend/internal/handlers/dropship_handler_test.go
@@ -24,7 +24,7 @@ type fakeDropshipService struct {
 	lastChan string
 }
 
-func (f *fakeDropshipService) ImportFromCSV(ctx context.Context, r io.Reader, channel string) (int, error) {
+func (f *fakeDropshipService) ImportFromCSV(ctx context.Context, r io.Reader, channel string, batchID int64) (int, error) {
 	f.lastChan = channel
 	if f.fail {
 		return 0, errors.New("fail import")

--- a/backend/internal/migrations/0061_add_journal_source_index.down.sql
+++ b/backend/internal/migrations/0061_add_journal_source_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS journal_entries_source_idx;

--- a/backend/internal/migrations/0061_add_journal_source_index.up.sql
+++ b/backend/internal/migrations/0061_add_journal_source_index.up.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX IF NOT EXISTS journal_entries_source_idx
+    ON journal_entries (source_type, source_id);

--- a/backend/internal/migrations/0062_create_batch_history_details.down.sql
+++ b/backend/internal/migrations/0062_create_batch_history_details.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS batch_history_details;

--- a/backend/internal/migrations/0062_create_batch_history_details.up.sql
+++ b/backend/internal/migrations/0062_create_batch_history_details.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS batch_history_details (
+    id SERIAL PRIMARY KEY,
+    batch_id INTEGER NOT NULL REFERENCES batch_history(id) ON DELETE CASCADE,
+    reference TEXT NOT NULL,
+    store TEXT,
+    status TEXT NOT NULL,
+    error_message TEXT
+);

--- a/backend/internal/models/batch.go
+++ b/backend/internal/models/batch.go
@@ -9,3 +9,13 @@ type BatchHistory struct {
 	Status      string `db:"status" json:"status"`
 	ErrorMsg    string `db:"error_message" json:"error_message"`
 }
+
+// BatchHistoryDetail records the result of processing a single transaction within a batch.
+type BatchHistoryDetail struct {
+	ID        int64  `db:"id" json:"id"`
+	BatchID   int64  `db:"batch_id" json:"batch_id"`
+	Reference string `db:"reference" json:"reference"`
+	Store     string `db:"store" json:"store"`
+	Status    string `db:"status" json:"status"`
+	ErrorMsg  string `db:"error_message" json:"error_message"`
+}

--- a/backend/internal/repository/batch_detail_repo.go
+++ b/backend/internal/repository/batch_detail_repo.go
@@ -1,0 +1,30 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/ramadhan22/dropship-erp/backend/internal/models"
+)
+
+// BatchDetailRepo handles operations for batch_history_details table.
+type BatchDetailRepo struct{ db DBTX }
+
+func NewBatchDetailRepo(db DBTX) *BatchDetailRepo { return &BatchDetailRepo{db: db} }
+
+func (r *BatchDetailRepo) Insert(ctx context.Context, d *models.BatchHistoryDetail) error {
+	query := `INSERT INTO batch_history_details (batch_id, reference, store, status, error_message)
+              VALUES (:batch_id, :reference, :store, :status, :error_message)`
+	_, err := sqlx.NamedExecContext(ctx, r.db, query, d)
+	return err
+}
+
+func (r *BatchDetailRepo) ListByBatchID(ctx context.Context, id int64) ([]models.BatchHistoryDetail, error) {
+	var list []models.BatchHistoryDetail
+	err := r.db.SelectContext(ctx, &list,
+		`SELECT * FROM batch_history_details WHERE batch_id=$1 ORDER BY id`, id)
+	if list == nil {
+		list = []models.BatchHistoryDetail{}
+	}
+	return list, err
+}

--- a/backend/internal/repository/journal_repo.go
+++ b/backend/internal/repository/journal_repo.go
@@ -31,11 +31,8 @@ func NewJournalRepo(db DBTX) *JournalRepo {
 // We need this so we can capture the returned primary key for inserting lines.
 func (r *JournalRepo) CreateJournalEntry(ctx context.Context, e *models.JournalEntry) (int64, error) {
 	if e.SourceType != "" && e.SourceID != "" {
-		old, err := r.GetJournalEntryBySource(ctx, e.SourceType, e.SourceID)
-		if err == nil && old != nil {
-			if err := r.DeleteJournalEntry(ctx, old.JournalID); err != nil {
-				return 0, err
-			}
+		if old, err := r.GetJournalEntryBySource(ctx, e.SourceType, e.SourceID); err == nil && old != nil {
+			return 0, fmt.Errorf("journal entry exists")
 		}
 	}
 	rows, err := sqlx.NamedQueryContext(ctx, r.db, insertJournalSQL, e)

--- a/backend/internal/repository/postgres_repository.go
+++ b/backend/internal/repository/postgres_repository.go
@@ -10,6 +10,7 @@ import (
 type Repository struct {
 	DB                   *sqlx.DB
 	BatchRepo            *BatchRepo
+	BatchDetailRepo      *BatchDetailRepo
 	DropshipRepo         *DropshipRepo
 	ShopeeRepo           *ShopeeRepo
 	ReconcileRepo        *ReconcileRepo
@@ -36,6 +37,7 @@ func NewPostgresRepository(databaseURL string) (*Repository, error) {
 
 	// Instantiate sub-repositories
 	batchRepo := NewBatchRepo(db)
+	batchDetailRepo := NewBatchDetailRepo(db)
 	dropshipRepo := NewDropshipRepo(db)
 	shopeeRepo := NewShopeeRepo(db)
 	reconcileRepo := NewReconcileRepo(db)
@@ -53,6 +55,7 @@ func NewPostgresRepository(databaseURL string) (*Repository, error) {
 	return &Repository{
 		DB:                   db,
 		BatchRepo:            batchRepo,
+		BatchDetailRepo:      batchDetailRepo,
 		DropshipRepo:         dropshipRepo,
 		ShopeeRepo:           shopeeRepo,
 		ReconcileRepo:        reconcileRepo,

--- a/backend/internal/service/batch_service.go
+++ b/backend/internal/service/batch_service.go
@@ -8,9 +8,14 @@ import (
 )
 
 // BatchService provides operations on batch_history.
-type BatchService struct{ repo *repository.BatchRepo }
+type BatchService struct {
+	repo       *repository.BatchRepo
+	detailRepo *repository.BatchDetailRepo
+}
 
-func NewBatchService(r *repository.BatchRepo) *BatchService { return &BatchService{repo: r} }
+func NewBatchService(r *repository.BatchRepo, d *repository.BatchDetailRepo) *BatchService {
+	return &BatchService{repo: r, detailRepo: d}
+}
 
 func (s *BatchService) Create(ctx context.Context, b *models.BatchHistory) (int64, error) {
 	return s.repo.Insert(ctx, b)
@@ -26,4 +31,18 @@ func (s *BatchService) UpdateStatus(ctx context.Context, id int64, status, msg s
 
 func (s *BatchService) List(ctx context.Context) ([]models.BatchHistory, error) {
 	return s.repo.List(ctx)
+}
+
+func (s *BatchService) CreateDetail(ctx context.Context, d *models.BatchHistoryDetail) error {
+	if s.detailRepo == nil {
+		return nil
+	}
+	return s.detailRepo.Insert(ctx, d)
+}
+
+func (s *BatchService) ListDetails(ctx context.Context, batchID int64) ([]models.BatchHistoryDetail, error) {
+	if s.detailRepo == nil {
+		return []models.BatchHistoryDetail{}, nil
+	}
+	return s.detailRepo.ListByBatchID(ctx, batchID)
 }

--- a/backend/internal/service/dropship_service_test.go
+++ b/backend/internal/service/dropship_service_test.go
@@ -190,10 +190,10 @@ func TestImportFromCSV_Success(t *testing.T) {
 	fake := &fakeDropshipRepo{}
 	jfake := &fakeJournalRepoDrop{}
 	srepo := &fakeStoreRepo{store: store}
-	svc := NewDropshipService(nil, fake, jfake, srepo, nil, client, 5)
+	svc := NewDropshipService(nil, fake, jfake, srepo, nil, nil, client, 5)
 
 	ctx := context.Background()
-	count, err := svc.ImportFromCSV(ctx, &buf, "")
+	count, err := svc.ImportFromCSV(ctx, &buf, "", 0)
 	if err != nil {
 		t.Fatalf("ImportFromCSV error: %v", err)
 	}
@@ -226,8 +226,8 @@ func TestImportFromCSV_ParseError(t *testing.T) {
 	w.Flush()
 
 	fake := &fakeDropshipRepo{}
-	svc := NewDropshipService(nil, fake, nil, nil, nil, nil, 5)
-	count, err := svc.ImportFromCSV(context.Background(), &buf, "")
+	svc := NewDropshipService(nil, fake, nil, nil, nil, nil, nil, 5)
+	count, err := svc.ImportFromCSV(context.Background(), &buf, "", 0)
 	if err == nil {
 		t.Fatal("expected parse error, got nil")
 	}
@@ -250,8 +250,8 @@ func TestImportFromCSV_SkipExisting(t *testing.T) {
 	w.Flush()
 
 	fake := &fakeDropshipRepo{existing: map[string]bool{"PS-EXIST": true}}
-	svc := NewDropshipService(nil, fake, nil, nil, nil, nil, 5)
-	count, err := svc.ImportFromCSV(context.Background(), &buf, "")
+	svc := NewDropshipService(nil, fake, nil, nil, nil, nil, nil, 5)
+	count, err := svc.ImportFromCSV(context.Background(), &buf, "", 0)
 	if err != nil {
 		t.Fatalf("ImportFromCSV error: %v", err)
 	}
@@ -304,9 +304,9 @@ func TestImportFromCSV_JournalSumsProducts(t *testing.T) {
 	fake := &fakeDropshipRepo{}
 	jfake := &fakeJournalRepoDrop{}
 	srepo := &fakeStoreRepo{store: store}
-	svc := NewDropshipService(nil, fake, jfake, srepo, nil, client, 5)
+	svc := NewDropshipService(nil, fake, jfake, srepo, nil, nil, client, 5)
 
-	count, err := svc.ImportFromCSV(context.Background(), &buf, "")
+	count, err := svc.ImportFromCSV(context.Background(), &buf, "", 0)
 	if err != nil {
 		t.Fatalf("ImportFromCSV error: %v", err)
 	}
@@ -344,9 +344,9 @@ func TestImportFromCSV_ChannelFilter(t *testing.T) {
 	w.Flush()
 
 	fake := &fakeDropshipRepo{}
-	svc := NewDropshipService(nil, fake, nil, nil, nil, nil, 5)
+	svc := NewDropshipService(nil, fake, nil, nil, nil, nil, nil, 5)
 
-	count, err := svc.ImportFromCSV(context.Background(), &buf, "Tokopedia")
+	count, err := svc.ImportFromCSV(context.Background(), &buf, "Tokopedia", 0)
 	if err != nil {
 		t.Fatalf("ImportFromCSV error: %v", err)
 	}
@@ -397,9 +397,9 @@ func TestImportFromCSV_SkipOnDetailError(t *testing.T) {
 
 	fakeRepo := &fakeDropshipRepo{}
 	srepo := &fakeStoreRepo{store: store}
-	svc := NewDropshipService(nil, fakeRepo, nil, srepo, nil, client, 5)
+	svc := NewDropshipService(nil, fakeRepo, nil, srepo, nil, nil, client, 5)
 
-	count, err := svc.ImportFromCSV(context.Background(), &buf, "")
+	count, err := svc.ImportFromCSV(context.Background(), &buf, "", 0)
 	if err != nil {
 		t.Fatalf("ImportFromCSV error: %v", err)
 	}

--- a/frontend/dropship-erp-ui/src/api/index.ts
+++ b/frontend/dropship-erp-ui/src/api/index.ts
@@ -468,6 +468,10 @@ export function listBatchHistory() {
   return api.get<BatchHistory[]>("/batches/");
 }
 
+export function listBatchDetails(batchID: number) {
+  return api.get<BatchHistoryDetail[]>(`/batches/${batchID}/details`);
+}
+
 export function fetchDashboard(params: {
   order?: string;
   channel?: string;

--- a/frontend/dropship-erp-ui/src/components/BatchHistoryPage.tsx
+++ b/frontend/dropship-erp-ui/src/components/BatchHistoryPage.tsx
@@ -1,11 +1,20 @@
 import { useEffect, useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from "@mui/material";
 import SortableTable from "./SortableTable";
 import type { Column } from "./SortableTable";
-import { listBatchHistory } from "../api";
-import type { BatchHistory } from "../types";
+import { listBatchHistory, listBatchDetails } from "../api";
+import type { BatchHistory, BatchHistoryDetail } from "../types";
 
 export default function BatchHistoryPage() {
   const [data, setData] = useState<BatchHistory[]>([]);
+  const [details, setDetails] = useState<BatchHistoryDetail[]>([]);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     listBatchHistory().then((res) => setData(res.data));
@@ -22,12 +31,45 @@ export default function BatchHistoryPage() {
     { label: "Done", key: "done_data", align: "right" },
     { label: "Status", key: "status" },
     { label: "Error", key: "error_message" },
+    {
+      label: "",
+      render: (_, row) => (
+        <Button
+          size="small"
+          onClick={() => {
+            listBatchDetails(row.id).then((r) => {
+              setDetails(r.data);
+              setOpen(true);
+            });
+          }}
+        >
+          View
+        </Button>
+      ),
+    },
   ];
 
   return (
     <div>
       <h2>Batch History</h2>
       <SortableTable columns={columns} data={data} />
+      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="md" fullWidth>
+        <DialogTitle>Batch Detail</DialogTitle>
+        <DialogContent>
+          <SortableTable
+            columns={[
+              { label: "Reference", key: "reference" },
+              { label: "Store", key: "store" },
+              { label: "Status", key: "status" },
+              { label: "Error", key: "error_message" },
+            ]}
+            data={details}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/dropship-erp-ui/src/types/index.ts
+++ b/frontend/dropship-erp-ui/src/types/index.ts
@@ -596,6 +596,15 @@ export interface BatchHistory {
   error_message: string;
 }
 
+export interface BatchHistoryDetail {
+  id: number;
+  batch_id: number;
+  reference: string;
+  store: string;
+  status: string;
+  error_message: string;
+}
+
 export interface DashboardData {
   summary: DashboardMetrics;
   charts: Record<string, { date: string; value: number }[]>;


### PR DESCRIPTION
## Summary
- track results of each import in new `batch_history_details` table
- prevent duplicate journal entries by checking existing record
- extend batch service to save detail rows
- update dropship import to record successes and existing data errors
- wire up new repository and service constructors
- expose batch details API and view detail dialog in the UI

## Testing
- `go test ./...`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687388e46da88327a0259da5ca9c9170