### PR TITLE
Implement dropship import scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Main features:
   Existing entries for the same order/date/type are replaced and they are also
   captured when importing settled orders.
   Adjustments can be browsed on the **Shopee Adjustments** page.
- - Multi-file imports are queued and processed in the background. The API
-   response reports how many files were queued so progress can be tracked.
+ - Multi-file imports are queued in `batch_history` and processed asynchronously
+   by a scheduler. The API response simply reports how many files were queued.
 Adjustments may be edited or deleted; updating replaces the original
 journal entry. Negative values are posted to a dedicated **Refund** account
 instead of the Discount account. The **Shipping Fee Discrepancy** sheet of the

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -3,9 +3,11 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -58,6 +60,8 @@ func main() {
 		shClient,
 		cfg.MaxThreads,
 	)
+	// process pending dropship imports in the background
+	service.NewDropshipImportScheduler(batchSvc, dropshipSvc, time.Minute).Start(context.Background())
 	shopeeSvc := service.NewShopeeService(repo.DB, repo.ShopeeRepo, repo.DropshipRepo, repo.JournalRepo, repo.ShopeeAdjustmentRepo)
 	reconSvc := service.NewReconcileService(
 		repo.DB,

--- a/backend/internal/handlers/dropship_handler_test.go
+++ b/backend/internal/handlers/dropship_handler_test.go
@@ -89,8 +89,8 @@ func TestHandleImport_Success(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
-	if svc.lastChan != "Shopee" {
-		t.Fatalf("expected channel passed to service")
+	if svc.lastChan != "" {
+		t.Fatalf("service should not be called")
 	}
 }
 

--- a/backend/internal/repository/batch_repo.go
+++ b/backend/internal/repository/batch_repo.go
@@ -59,3 +59,16 @@ func (r *BatchRepo) List(ctx context.Context) ([]models.BatchHistory, error) {
 	}
 	return list, err
 }
+
+// ListByProcessAndStatus returns batch records matching the given process type
+// and status ordered by ID.
+func (r *BatchRepo) ListByProcessAndStatus(ctx context.Context, typ, status string) ([]models.BatchHistory, error) {
+	var list []models.BatchHistory
+	err := r.db.SelectContext(ctx, &list,
+		`SELECT * FROM batch_history WHERE process_type=$1 AND status=$2 ORDER BY id`,
+		typ, status)
+	if list == nil {
+		list = []models.BatchHistory{}
+	}
+	return list, err
+}

--- a/backend/internal/service/batch_service.go
+++ b/backend/internal/service/batch_service.go
@@ -51,3 +51,8 @@ func (s *BatchService) ListDetails(ctx context.Context, batchID int64) ([]models
 	}
 	return s.detailRepo.ListByBatchID(ctx, batchID)
 }
+
+// ListPendingByType returns batches with the given process type and status 'pending'.
+func (s *BatchService) ListPendingByType(ctx context.Context, typ string) ([]models.BatchHistory, error) {
+	return s.repo.ListByProcessAndStatus(ctx, typ, "pending")
+}

--- a/backend/internal/service/dropship_import_processor.go
+++ b/backend/internal/service/dropship_import_processor.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"context"
+	"encoding/csv"
+	"io"
+	"os"
+)
+
+// ProcessImportFile reads the CSV file at the given path and stores its rows.
+// Batch progress is recorded using the BatchService if available.
+func (s *DropshipService) ProcessImportFile(ctx context.Context, batchID int64, path, channel string) {
+	f, err := os.Open(path)
+	if err != nil {
+		if s.batchSvc != nil {
+			s.batchSvc.UpdateStatus(ctx, batchID, "failed", err.Error())
+		}
+		return
+	}
+	defer f.Close()
+
+	var total int
+	if s.batchSvc != nil {
+		total, err = countCSVRows(f)
+		if err != nil {
+			s.batchSvc.UpdateStatus(ctx, batchID, "failed", err.Error())
+			return
+		}
+		s.batchSvc.UpdateTotal(ctx, batchID, total)
+		s.batchSvc.UpdateStatus(ctx, batchID, "processing", "")
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			s.batchSvc.UpdateStatus(ctx, batchID, "failed", err.Error())
+			return
+		}
+	}
+
+	count, err := s.ImportFromCSV(ctx, f, channel, batchID)
+	if s.batchSvc != nil {
+		s.batchSvc.UpdateDone(ctx, batchID, count)
+		if err != nil {
+			s.batchSvc.UpdateStatus(ctx, batchID, "failed", err.Error())
+		} else {
+			s.batchSvc.UpdateStatus(ctx, batchID, "completed", "")
+		}
+	}
+}
+
+// countCSVRows returns the number of data rows in a CSV reader.
+// It expects the first line to be a header and ignores it.
+func countCSVRows(r io.Reader) (int, error) {
+	reader := csv.NewReader(r)
+	if _, err := reader.Read(); err != nil {
+		return 0, err
+	}
+	n := 0
+	for {
+		if _, err := reader.Read(); err == io.EOF {
+			break
+		} else if err != nil {
+			return n, err
+		} else {
+			n++
+		}
+	}
+	return n, nil
+}

--- a/backend/internal/service/dropship_import_scheduler.go
+++ b/backend/internal/service/dropship_import_scheduler.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// DropshipImportScheduler periodically processes pending dropship import batches.
+type DropshipImportScheduler struct {
+	batch    *BatchService
+	svc      *DropshipService
+	interval time.Duration
+}
+
+// NewDropshipImportScheduler creates a scheduler with the given interval.
+// If interval is zero a default of one minute is used.
+func NewDropshipImportScheduler(batch *BatchService, svc *DropshipService, interval time.Duration) *DropshipImportScheduler {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	return &DropshipImportScheduler{batch: batch, svc: svc, interval: interval}
+}
+
+// Start launches the scheduler loop.
+func (s *DropshipImportScheduler) Start(ctx context.Context) {
+	if s == nil {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(s.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.run(ctx)
+			}
+		}
+	}()
+}
+
+func (s *DropshipImportScheduler) run(ctx context.Context) {
+	list, err := s.batch.ListPendingByType(ctx, "dropship_import")
+	if err != nil {
+		log.Printf("scheduler list pending: %v", err)
+		return
+	}
+	for _, b := range list {
+		s.svc.ProcessImportFile(ctx, b.ID, b.FilePath, "")
+	}
+}


### PR DESCRIPTION
## Summary
- add scheduler to process pending dropship imports
- refactor dropship import handler to only queue files
- expose batch listing helper and import processor
- document scheduler behaviour in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6873bee2c4a4832790a3f16035ed8051