### PR TITLE
Support free sample import

### DIFF
--- a/backend/internal/migrations/0064_add_free_sample_account.down.sql
+++ b/backend/internal/migrations/0064_add_free_sample_account.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM accounts WHERE account_code='5.5.7';

--- a/backend/internal/migrations/0064_add_free_sample_account.up.sql
+++ b/backend/internal/migrations/0064_add_free_sample_account.up.sql
@@ -1,0 +1,8 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM accounts WHERE account_code='5.5.7') THEN
+        INSERT INTO accounts (account_id, account_code, account_name, account_type, parent_id)
+        VALUES (55007, '5.5.7', 'Free Sample', 'Expense',
+            (SELECT account_id FROM accounts WHERE account_code='5.5'));
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- handle 'MR eStore Free Sample' store in dropship import
- create journal entry debiting marketing free sample account and crediting Saldo Jakmall
- mark purchase completed for this store
- add migration to create the free sample account if missing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6873caf98b8083279a2b72d5c5b1e6f9