### PR TITLE
Fix escrow settlement and token logging

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -62,7 +62,7 @@ func main() {
 	)
 	// process pending dropship imports in the background
 	service.NewDropshipImportScheduler(batchSvc, dropshipSvc, time.Minute).Start(context.Background())
-	shopeeSvc := service.NewShopeeService(repo.DB, repo.ShopeeRepo, repo.DropshipRepo, repo.JournalRepo, repo.ShopeeAdjustmentRepo)
+	shopeeSvc := service.NewShopeeService(repo.DB, repo.ShopeeRepo, repo.DropshipRepo, repo.JournalRepo, repo.ShopeeAdjustmentRepo, cfg.Shopee)
 	reconSvc := service.NewReconcileService(
 		repo.DB,
 		repo.DropshipRepo, repo.ShopeeRepo, repo.JournalRepo, repo.ReconcileRepo,

--- a/backend/internal/service/shopee_service_test.go
+++ b/backend/internal/service/shopee_service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/xuri/excelize/v2"
 
+	"github.com/ramadhan22/dropship-erp/backend/internal/config"
 	"github.com/ramadhan22/dropship-erp/backend/internal/models"
 	"github.com/ramadhan22/dropship-erp/backend/internal/repository"
 )
@@ -231,7 +232,7 @@ func TestImportSettledOrdersXLSX(t *testing.T) {
 	}
 
 	repo := &fakeShopeeRepo{existingSettled: map[string]bool{"SO1": true}}
-	svc := NewShopeeService(nil, repo, nil, nil, nil)
+	svc := NewShopeeService(nil, repo, nil, nil, nil, config.ShopeeAPIConfig{})
 	inserted, _, err := svc.ImportSettledOrdersXLSX(context.Background(), bytes.NewReader(buf.Bytes()))
 	if err != nil {
 		t.Fatalf("import error: %v", err)
@@ -253,7 +254,7 @@ func TestImportSettledOrdersXLSX_HeaderMismatch(t *testing.T) {
 	}
 
 	repo := &fakeShopeeRepo{existingSettled: map[string]bool{"SO1": true}}
-	svc := NewShopeeService(nil, repo, nil, nil, nil)
+	svc := NewShopeeService(nil, repo, nil, nil, nil, config.ShopeeAPIConfig{})
 	_, _, err := svc.ImportSettledOrdersXLSX(context.Background(), bytes.NewReader(buf.Bytes()))
 	if err == nil {
 		t.Fatalf("expected error due to header mismatch")
@@ -289,7 +290,7 @@ func TestImportSettledOrdersXLSX_SkipDuplicates(t *testing.T) {
 	}
 
 	repo := &fakeShopeeRepo{existingSettled: map[string]bool{"SO-1": true}}
-	svc := NewShopeeService(nil, repo, nil, nil, nil)
+	svc := NewShopeeService(nil, repo, nil, nil, nil, config.ShopeeAPIConfig{})
 	inserted, _, err := svc.ImportSettledOrdersXLSX(context.Background(), bytes.NewReader(buf.Bytes()))
 	if err != nil {
 		t.Fatalf("import error: %v", err)
@@ -331,7 +332,7 @@ func TestImportSettledOrdersXLSX_UpdateDropshipStatus(t *testing.T) {
 	drop := &fakeDropRepoA{byTrans: map[string]*models.DropshipPurchase{
 		"TRX-1": {KodePesanan: "DP1", StatusPesananTerakhir: "Diproses"},
 	}}
-	svc := NewShopeeService(nil, repo, drop, nil, nil)
+	svc := NewShopeeService(nil, repo, drop, nil, nil, config.ShopeeAPIConfig{})
 	inserted, _, err := svc.ImportSettledOrdersXLSX(context.Background(), bytes.NewReader(buf.Bytes()))
 	if err != nil {
 		t.Fatalf("import error: %v", err)
@@ -348,7 +349,7 @@ func TestImportAffiliateCSV(t *testing.T) {
 	csvData := "Kode Pesanan,Status Pesanan,Status Terverifikasi,Waktu Pesanan,Waktu Pesanan Selesai,Waktu Pesanan Terverifikasi,Kode Produk,Nama Produk,ID Model,L1 Kategori Global,L2 Kategori Global,L3 Kategori Global,Kode Promo,Harga(Rp),Jumlah,Nama Affiliate,Username Affiliate,MCN Terhubung,ID Komisi Pesanan,Partner Promo,Jenis Promo,Nilai Pembelian(Rp),Jumlah Pengembalian(Rp),Tipe Pesanan,Estimasi Komisi per Produk(Rp),Estimasi Komisi Affiliate per Produk(Rp),Persentase Komisi Affiliate per Produk,Estimasi Komisi MCN per Produk(Rp),Persentase Komisi MCN per Produk,Estimasi Komisi per Pesanan(Rp),Estimasi Komisi Affiliate per Pesanan(Rp),Estimasi Komisi MCN per Pesanan(Rp),Catatan Produk,Platform,Tingkat Komisi,Pengeluaran(Rp),Status Pemotongan,Metode Pemotongan,Waktu Pemotongan\n" +
 		"SO1,Selesai,Sah,2025-06-01 10:00:00,,,P1,Produk,ID1,Cat1,Cat2,Cat3,,1000,1,Aff,affuser,,1,,Promo,1000,0,Langsung,10,10,10%,0,0%,10,10,0,,IG,10%,0,,,"
 	repo := &fakeShopeeRepo{existingSettled: map[string]bool{"SO1": true}}
-	svc := NewShopeeService(nil, repo, nil, nil, nil)
+	svc := NewShopeeService(nil, repo, nil, nil, nil, config.ShopeeAPIConfig{})
 	inserted, err := svc.ImportAffiliateCSV(context.Background(), strings.NewReader(csvData))
 	if err != nil {
 		t.Fatalf("import error: %v", err)
@@ -363,7 +364,7 @@ func TestImportAffiliateCSV_JournalEntry(t *testing.T) {
 		"SO1,Selesai,Sah,2025-06-01 10:00:00,,,P1,Produk,ID1,Cat1,Cat2,Cat3,,1000,1,Aff,affuser,,1,,Promo,1000,0,Langsung,10,10,10%,0,0%,10,10,0,,IG,10%,5,,,"
 	repo := &fakeShopeeRepo{existingSettled: map[string]bool{"SO1": true}}
 	jr := &fakeJournalRepoS{}
-	svc := NewShopeeService(nil, repo, nil, jr, nil)
+	svc := NewShopeeService(nil, repo, nil, jr, nil, config.ShopeeAPIConfig{})
 	inserted, err := svc.ImportAffiliateCSV(context.Background(), strings.NewReader(csvData))
 	if err != nil {
 		t.Fatalf("import error: %v", err)
@@ -390,7 +391,7 @@ func TestImportAffiliateCSV_SkipDuplicate(t *testing.T) {
 		existingAffiliate: map[string]bool{"SO1|P1|1": true},
 	}
 	jr := &fakeJournalRepoS{}
-	svc := NewShopeeService(nil, repo, nil, jr, nil)
+	svc := NewShopeeService(nil, repo, nil, jr, nil, config.ShopeeAPIConfig{})
 	inserted, err := svc.ImportAffiliateCSV(context.Background(), strings.NewReader(csvData))
 	if err != nil {
 		t.Fatalf("import error: %v", err)
@@ -411,7 +412,7 @@ func TestImportAffiliateCSV_SkipMissingOrder(t *testing.T) {
 		"SO1": {NamaToko: "TOKO"},
 	}}
 	jr := &fakeJournalRepoS{}
-	svc := NewShopeeService(nil, repo, drop, jr, nil)
+	svc := NewShopeeService(nil, repo, drop, jr, nil, config.ShopeeAPIConfig{})
 	inserted, err := svc.ImportAffiliateCSV(context.Background(), strings.NewReader(csvData))
 	if err != nil {
 		t.Fatalf("import error: %v", err)
@@ -428,7 +429,7 @@ func TestImportAffiliateCSV_FilterStatus(t *testing.T) {
 	csvData := "Kode Pesanan,Status Pesanan,Status Terverifikasi,Waktu Pesanan,Waktu Pesanan Selesai,Waktu Pesanan Terverifikasi,Kode Produk,Nama Produk,IDModel,L1 Kategori Global,L2 Kategori Global,L3 Kategori Global,Kode Promo,Harga(Rp),Jumlah,Nama Affiliate,Username Affiliate,MCN Terhubung,ID Komisi Pesanan,Partner Promo,Jenis Promo,Nilai Pembelian(Rp),Jumlah Pengembalian(Rp),Tipe Pesanan,Estimasi Komisi per Produk(Rp),Estimasi Komisi Affiliate per Produk(Rp),Persentase Komisi Affiliate per Produk,Estimasi Komisi MCN per Produk(Rp),Persentase Komisi MCN per Produk,Estimasi Komisi per Pesanan(Rp),Estimasi Komisi Affiliate per Pesanan(Rp),Estimasi Komisi MCN per Pesanan(Rp),Catatan Produk,Platform,Tingkat Komisi,Pengeluaran(Rp),Status Pemotongan,Metode Pemotongan,Waktu Pemotongan\n" +
 		"SO1,Sedang Dikirim,Sah,2025-06-01 10:00:00,,,P1,Produk,ID1,Cat1,Cat2,Cat3,,1000,1,Aff,affuser,,1,,Promo,1000,0,Langsung,10,10,10%,0,0%,10,10,0,,IG,10%,0,,,"
 	repo := &fakeShopeeRepo{}
-	svc := NewShopeeService(nil, repo, nil, nil, nil)
+	svc := NewShopeeService(nil, repo, nil, nil, nil, config.ShopeeAPIConfig{})
 	inserted, err := svc.ImportAffiliateCSV(context.Background(), strings.NewReader(csvData))
 	if err != nil {
 		t.Fatalf("import error: %v", err)
@@ -443,7 +444,7 @@ func TestImportAffiliateCSV_NonSahNoJournal(t *testing.T) {
 		"SO1,Selesai,Tidak,2025-06-01 10:00:00,,,P1,Produk,ID1,Cat1,Cat2,Cat3,,1000,1,Aff,affuser,,1,,Promo,1000,0,Langsung,10,10,10%,0,0%,10,10,0,,IG,10%,5,,,"
 	repo := &fakeShopeeRepo{existingSettled: map[string]bool{"SO1": true}}
 	jr := &fakeJournalRepoS{}
-	svc := NewShopeeService(nil, repo, nil, jr, nil)
+	svc := NewShopeeService(nil, repo, nil, jr, nil, config.ShopeeAPIConfig{})
 	inserted, err := svc.ImportAffiliateCSV(context.Background(), strings.NewReader(csvData))
 	if err != nil {
 		t.Fatalf("import error: %v", err)
@@ -472,7 +473,7 @@ func TestConfirmSettleCreatesFeeLines(t *testing.T) {
 		affExpense: 1,
 	}
 	jr := &fakeJournalRepoS{}
-	svc := NewShopeeService(nil, repo, nil, jr, nil)
+	svc := NewShopeeService(nil, repo, nil, jr, nil, config.ShopeeAPIConfig{})
 
 	if err := svc.ConfirmSettle(context.Background(), "SO1"); err != nil {
 		t.Fatalf("confirm error: %v", err)
@@ -506,7 +507,7 @@ func TestConfirmSettleMismatchCreatesAdjustment(t *testing.T) {
 		"SO2": {TotalTransaksi: 100},
 	}}
 	jr := &fakeJournalRepoS{}
-	svc := NewShopeeService(nil, repo, drop, jr, nil)
+	svc := NewShopeeService(nil, repo, drop, jr, nil, config.ShopeeAPIConfig{})
 
 	if err := svc.ConfirmSettle(context.Background(), "SO2"); err != nil {
 		t.Fatalf("confirm error: %v", err)
@@ -558,7 +559,7 @@ func TestImportSettledOrdersXLSX_AutoSettle(t *testing.T) {
 		"SO-3": {TotalTransaksi: 1},
 	}}
 	jr := &fakeJournalRepoS{}
-	svc := NewShopeeService(nil, repo, drop, jr, nil)
+	svc := NewShopeeService(nil, repo, drop, jr, nil, config.ShopeeAPIConfig{})
 	inserted, mis, err := svc.ImportSettledOrdersXLSX(context.Background(), bytes.NewReader(buf.Bytes()))
 	if err != nil {
 		t.Fatalf("import error: %v", err)
@@ -614,7 +615,7 @@ func TestImportSettledOrdersXLSX_AutoAdjustMismatch(t *testing.T) {
 		"SO-4": {TotalTransaksi: 100},
 	}}
 	jr := &fakeJournalRepoS{}
-	svc := NewShopeeService(nil, repo, drop, jr, nil)
+	svc := NewShopeeService(nil, repo, drop, jr, nil, config.ShopeeAPIConfig{})
 	inserted, mis, err := svc.ImportSettledOrdersXLSX(context.Background(), bytes.NewReader(buf.Bytes()))
 	if err != nil {
 		t.Fatalf("import error: %v", err)


### PR DESCRIPTION
## Summary
- handle order_sn vs invoice code mismatch during escrow settlement batches
- reduce verbose escrow logs
- remove debug prefix from `ensureStoreTokenValid`
- inject Shopee config into `ShopeeService`
- adjust unit tests accordingly

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6873e6325f748327b3b78b46dd03e5ae