### PR TITLE
Implement async reconcile batches

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -73,6 +73,7 @@ func main() {
 		batchSvc,
 		cfg.MaxThreads,
 	)
+	service.NewReconcileBatchScheduler(batchSvc, reconSvc, time.Minute).Start(context.Background())
 	metricSvc := service.NewMetricService(
 		repo.DropshipRepo, repo.ShopeeRepo, repo.JournalRepo, repo.MetricRepo,
 	)

--- a/backend/internal/repository/batch_detail_repo.go
+++ b/backend/internal/repository/batch_detail_repo.go
@@ -28,3 +28,10 @@ func (r *BatchDetailRepo) ListByBatchID(ctx context.Context, id int64) ([]models
 	}
 	return list, err
 }
+
+func (r *BatchDetailRepo) UpdateStatus(ctx context.Context, id int64, status, msg string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE batch_history_details SET status=$2, error_message=$3 WHERE id=$1`,
+		id, status, msg)
+	return err
+}

--- a/backend/internal/service/batch_service.go
+++ b/backend/internal/service/batch_service.go
@@ -52,6 +52,13 @@ func (s *BatchService) ListDetails(ctx context.Context, batchID int64) ([]models
 	return s.detailRepo.ListByBatchID(ctx, batchID)
 }
 
+func (s *BatchService) UpdateDetailStatus(ctx context.Context, id int64, status, msg string) error {
+	if s.detailRepo == nil {
+		return nil
+	}
+	return s.detailRepo.UpdateStatus(ctx, id, status, msg)
+}
+
 // ListPendingByType returns batches with the given process type and status 'pending'.
 func (s *BatchService) ListPendingByType(ctx context.Context, typ string) ([]models.BatchHistory, error) {
 	return s.repo.ListByProcessAndStatus(ctx, typ, "pending")

--- a/backend/internal/service/reconcile_batch_scheduler.go
+++ b/backend/internal/service/reconcile_batch_scheduler.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/ramadhan22/dropship-erp/backend/internal/models"
+)
+
+// ReconcileBatchScheduler processes pending reconcile batches in the background.
+type ReconcileBatchScheduler struct {
+	batch    *BatchService
+	svc      *ReconcileService
+	interval time.Duration
+}
+
+// NewReconcileBatchScheduler creates a scheduler with the given interval.
+func NewReconcileBatchScheduler(batch *BatchService, svc *ReconcileService, interval time.Duration) *ReconcileBatchScheduler {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	return &ReconcileBatchScheduler{batch: batch, svc: svc, interval: interval}
+}
+
+// Start launches the scheduler loop.
+func (s *ReconcileBatchScheduler) Start(ctx context.Context) {
+	if s == nil {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(s.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.run(ctx)
+			}
+		}
+	}()
+}
+
+func (s *ReconcileBatchScheduler) run(ctx context.Context) {
+	list, err := s.batch.ListPendingByType(ctx, "reconcile_batch")
+	if err != nil {
+		log.Printf("scheduler list pending: %v", err)
+		return
+	}
+	limit := s.svc.maxThreads
+	if limit <= 0 {
+		limit = 5
+	}
+	sem := make(chan struct{}, limit)
+	var wg sync.WaitGroup
+	for _, b := range list {
+		batch := b
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(bb models.BatchHistory) {
+			defer func() { <-sem; wg.Done() }()
+			s.svc.ProcessReconcileBatch(ctx, bb.ID)
+		}(batch)
+	}
+	wg.Wait()
+}

--- a/backend/internal/service/reconcile_service_batch_test.go
+++ b/backend/internal/service/reconcile_service_batch_test.go
@@ -90,6 +90,16 @@ func (f *fakeBatchSvc) UpdateStatus(ctx context.Context, id int64, status, msg s
 	return nil
 }
 
+func (f *fakeBatchSvc) CreateDetail(ctx context.Context, d *models.BatchHistoryDetail) error {
+	return nil
+}
+func (f *fakeBatchSvc) ListDetails(ctx context.Context, id int64) ([]models.BatchHistoryDetail, error) {
+	return []models.BatchHistoryDetail{}, nil
+}
+func (f *fakeBatchSvc) UpdateDetailStatus(ctx context.Context, id int64, status, msg string) error {
+	return nil
+}
+
 func TestProcessShopeeStatusBatch_Escrow(t *testing.T) {
 	dp1 := &models.DropshipPurchase{KodePesanan: "DP1", KodeInvoiceChannel: "INV1", NamaToko: "ShopA"}
 	dp2 := &models.DropshipPurchase{KodePesanan: "DP2", KodeInvoiceChannel: "INV2", NamaToko: "ShopA"}

--- a/frontend/dropship-erp-ui/src/api/reconcile.ts
+++ b/frontend/dropship-erp-ui/src/api/reconcile.ts
@@ -73,3 +73,12 @@ export function updateShopeeStatuses(
 ) {
   return api.post("/reconcile/update_statuses", { invoices }, config);
 }
+
+export function createReconcileBatch(
+  shop: string,
+  order: string,
+  from: string,
+  to: string,
+) {
+  return api.post("/reconcile/batch", { shop, order, from, to });
+}


### PR DESCRIPTION
## Summary
- add batch history update helpers
- implement async reconcile batch creation and processing
- expose new route for batch reconcile and scheduler
- adjust frontend to trigger batch creation

## Testing
- `go test ./...`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687518f3fa388327b612d4401f02dce7