### PR TITLE
Add batch history filters and detail fields

### DIFF
--- a/backend/internal/handlers/batch_handler.go
+++ b/backend/internal/handlers/batch_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/ramadhan22/dropship-erp/backend/internal/service"
@@ -21,7 +22,25 @@ func (h *BatchHandler) RegisterRoutes(r gin.IRouter) {
 }
 
 func (h *BatchHandler) list(c *gin.Context) {
-	list, err := h.svc.List(context.Background())
+	statusStr := c.DefaultQuery("status", "pending,processing")
+	statuses := []string{}
+	for _, s := range strings.Split(statusStr, ",") {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			statuses = append(statuses, s)
+		}
+	}
+	typeStr := c.Query("type")
+	types := []string{}
+	if typeStr != "" {
+		for _, t := range strings.Split(typeStr, ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				types = append(types, t)
+			}
+		}
+	}
+	list, err := h.svc.ListFiltered(context.Background(), types, statuses)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/handlers/batch_handler.go
+++ b/backend/internal/handlers/batch_handler.go
@@ -22,7 +22,7 @@ func (h *BatchHandler) RegisterRoutes(r gin.IRouter) {
 }
 
 func (h *BatchHandler) list(c *gin.Context) {
-	statusStr := c.DefaultQuery("status", "pending,processing")
+	statusStr := c.DefaultQuery("status", DefaultStatusValues)
 	statuses := []string{}
 	for _, s := range strings.Split(statusStr, ",") {
 		s = strings.TrimSpace(s)

--- a/backend/internal/service/batch_service.go
+++ b/backend/internal/service/batch_service.go
@@ -38,6 +38,14 @@ func (s *BatchService) List(ctx context.Context) ([]models.BatchHistory, error) 
 	return s.repo.List(ctx)
 }
 
+// ListFiltered retrieves batch history records filtered by types and statuses.
+func (s *BatchService) ListFiltered(ctx context.Context, types, statuses []string) ([]models.BatchHistory, error) {
+	if len(types) == 0 && len(statuses) == 0 {
+		return s.repo.List(ctx)
+	}
+	return s.repo.ListFiltered(ctx, types, statuses)
+}
+
 func (s *BatchService) CreateDetail(ctx context.Context, d *models.BatchHistoryDetail) error {
 	if s.detailRepo == nil {
 		return nil

--- a/frontend/dropship-erp-ui/src/api/index.ts
+++ b/frontend/dropship-erp-ui/src/api/index.ts
@@ -168,7 +168,9 @@ export function deleteStore(id: number) {
 }
 
 export function fetchShopeeAuthURL(storeId: number) {
-  return api.get<{ url: string }>(`/config/shopee-auth-url?store_id=${storeId}`);
+  return api.get<{ url: string }>(
+    `/config/shopee-auth-url?store_id=${storeId}`,
+  );
 }
 
 export function listJenisChannels() {
@@ -451,7 +453,12 @@ export const withdrawShopeeBalance = (store: string, amount: number) =>
 export const fetchPendingBalance = (store: string) =>
   api.get<{ pending_balance: number }>(`/pending-balance?store=${store}`);
 
-export function listOrderDetails(params: { store?: string; order?: string; page?: number; page_size?: number }) {
+export function listOrderDetails(params: {
+  store?: string;
+  order?: string;
+  page?: number;
+  page_size?: number;
+}) {
   const q = new URLSearchParams();
   if (params.store) q.append("store", params.store);
   if (params.order) q.append("order", params.order);
@@ -463,13 +470,24 @@ export function listOrderDetails(params: { store?: string; order?: string; page?
 }
 
 export function getOrderDetail(sn: string) {
-  return api.get<{ detail: ShopeeOrderDetailRow; items: ShopeeOrderItemRow[]; packages: ShopeeOrderPackageRow[] }>(
-    `/order-details/${sn}`,
-  );
+  return api.get<{
+    detail: ShopeeOrderDetailRow;
+    items: ShopeeOrderItemRow[];
+    packages: ShopeeOrderPackageRow[];
+  }>(`/order-details/${sn}`);
 }
 
-export function listBatchHistory() {
-  return api.get<BatchHistory[]>("/batches/");
+export function listBatchHistory(params?: {
+  status?: string[];
+  type?: string;
+}) {
+  const q = new URLSearchParams();
+  if (params?.status && params.status.length > 0)
+    q.append("status", params.status.join(","));
+  if (params?.type) q.append("type", params.type);
+  const qs = q.toString();
+  const url = qs ? `/batches/?${qs}` : "/batches/";
+  return api.get<BatchHistory[]>(url);
 }
 
 export function listBatchDetails(batchID: number) {

--- a/frontend/dropship-erp-ui/src/components/BatchHistoryPage.tsx
+++ b/frontend/dropship-erp-ui/src/components/BatchHistoryPage.tsx
@@ -15,12 +15,17 @@ export default function BatchHistoryPage() {
   const [data, setData] = useState<BatchHistory[]>([]);
   const [details, setDetails] = useState<BatchHistoryDetail[]>([]);
   const [open, setOpen] = useState(false);
+  const [status, setStatus] = useState<string[]>(["pending", "processing"]);
+  const [typ, setTyp] = useState("");
 
   useEffect(() => {
-    listBatchHistory().then((res) => setData(res.data));
-  }, []);
+    listBatchHistory({ status, type: typ || undefined }).then((res) =>
+      setData(res.data),
+    );
+  }, [status, typ]);
 
   const columns: Column<BatchHistory>[] = [
+    { label: "ID", key: "id" },
     { label: "Type", key: "process_type" },
     {
       label: "Started",
@@ -31,6 +36,8 @@ export default function BatchHistoryPage() {
     { label: "Done", key: "done_data", align: "right" },
     { label: "Status", key: "status" },
     { label: "Error", key: "error_message" },
+    { label: "File", key: "file_name" },
+    { label: "Path", key: "file_path" },
     {
       label: "",
       render: (_, row) => (
@@ -52,12 +59,39 @@ export default function BatchHistoryPage() {
   return (
     <div>
       <h2>Batch History</h2>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem" }}>
+        <select
+          multiple
+          value={status}
+          onChange={(e) =>
+            setStatus(Array.from(e.target.selectedOptions).map((o) => o.value))
+          }
+        >
+          <option value="pending">pending</option>
+          <option value="processing">processing</option>
+          <option value="completed">completed</option>
+          <option value="failed">failed</option>
+        </select>
+        <input
+          placeholder="Type"
+          value={typ}
+          onChange={(e) => setTyp(e.target.value)}
+          style={{ height: "2rem" }}
+        />
+      </div>
       <SortableTable columns={columns} data={data} />
-      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="md" fullWidth>
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        maxWidth="md"
+        fullWidth
+      >
         <DialogTitle>Batch Detail</DialogTitle>
         <DialogContent>
           <SortableTable
             columns={[
+              { label: "ID", key: "id" },
+              { label: "Batch", key: "batch_id" },
               { label: "Reference", key: "reference" },
               { label: "Store", key: "store" },
               { label: "Status", key: "status" },

--- a/frontend/dropship-erp-ui/src/components/BatchHistoryPage.tsx
+++ b/frontend/dropship-erp-ui/src/components/BatchHistoryPage.tsx
@@ -15,7 +15,8 @@ export default function BatchHistoryPage() {
   const [data, setData] = useState<BatchHistory[]>([]);
   const [details, setDetails] = useState<BatchHistoryDetail[]>([]);
   const [open, setOpen] = useState(false);
-  const [status, setStatus] = useState<string[]>(["pending", "processing"]);
+  const DEFAULT_STATUSES = ["pending", "processing", "completed", "failed"];
+  const [status, setStatus] = useState<string[]>(DEFAULT_STATUSES.slice(0, 2));
   const [typ, setTyp] = useState("");
 
   useEffect(() => {

--- a/frontend/dropship-erp-ui/src/types/index.ts
+++ b/frontend/dropship-erp-ui/src/types/index.ts
@@ -594,6 +594,8 @@ export interface BatchHistory {
   done_data: number;
   status: string;
   error_message: string;
+  file_name: string;
+  file_path: string;
 }
 
 export interface BatchHistoryDetail {


### PR DESCRIPTION
## Summary
- show all batch history fields
- add status/type filters in BatchHistoryPage
- allow filtering via backend BatchHandler and BatchService
- extend BatchHistory types

## Testing
- `go test ./...` *(fails: cannot use &mockServiceWrapper as *service.AdsPerformanceService)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877855f66a88327bf8edd9fa536cb71