### PR TITLE
Add status filter for Reconcile dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Discrepancy* adjustment when they differ.
   concurrently for faster imports.
 - Shopee order status is now fetched server-side when loading the Reconcile dashboard for faster rendering.
 - Filter reconcile candidates by date range to limit results.
+- Reconcile dashboard now supports filtering candidates by purchase status.
 - Reconcile All now creates batch records grouped by store (50 invoices per batch) and returns immediately. The scheduler processes these batches asynchronously.
 - Escrow details are fetched in batches of up to 50 orders when reconciling all, reducing API requests.
 - Shopee reconciliation batches run in parallel for faster processing.

--- a/backend/internal/repository/reconcile_repo_test.go
+++ b/backend/internal/repository/reconcile_repo_test.go
@@ -109,7 +109,7 @@ func TestListCandidates(t *testing.T) {
 	}
 	_, _ = jrepo.CreateJournalEntry(ctx, escrow)
 
-	list, total, err := recRepo.ListCandidates(ctx, "ShopA", "", "", "", 10, 0)
+	list, total, err := recRepo.ListCandidates(ctx, "ShopA", "", "", "", "", 10, 0)
 	if err != nil {
 		t.Fatalf("ListCandidates error: %v", err)
 	}
@@ -117,12 +117,20 @@ func TestListCandidates(t *testing.T) {
 		t.Errorf("expected 1 candidate, got %d total %d", len(list), total)
 	}
 
-	list2, total2, err := recRepo.ListCandidates(ctx, "", kode1, "", "", 10, 0)
+	list2, total2, err := recRepo.ListCandidates(ctx, "", kode1, "", "", "", 10, 0)
 	if err != nil {
 		t.Fatalf("ListCandidates by order error: %v", err)
 	}
 	if len(list2) != 1 || total2 != 1 {
 		t.Errorf("expected 1 candidate, got %d total %d", len(list2), total2)
+	}
+
+	list3, total3, err := recRepo.ListCandidates(ctx, "", "", "diproses", "", "", 10, 0)
+	if err != nil {
+		t.Fatalf("ListCandidates by status error: %v", err)
+	}
+	if len(list3) == 0 || total3 == 0 {
+		t.Errorf("expected candidates by status, got %d total %d", len(list3), total3)
 	}
 
 	// cleanup

--- a/backend/internal/service/reconcile_service.go
+++ b/backend/internal/service/reconcile_service.go
@@ -283,11 +283,11 @@ func (s *ReconcileService) ListUnmatched(ctx context.Context, shop string) ([]mo
 }
 
 // ListCandidates proxies to the repo to fetch transactions that need attention.
-func (s *ReconcileService) ListCandidates(ctx context.Context, shop, order, from, to string, limit, offset int) ([]models.ReconcileCandidate, int, error) {
+func (s *ReconcileService) ListCandidates(ctx context.Context, shop, order, status, from, to string, limit, offset int) ([]models.ReconcileCandidate, int, error) {
 	if repo, ok := s.recRepo.(interface {
-		ListCandidates(context.Context, string, string, string, string, int, int) ([]models.ReconcileCandidate, int, error)
+		ListCandidates(context.Context, string, string, string, string, string, int, int) ([]models.ReconcileCandidate, int, error)
 	}); ok {
-		list, total, err := repo.ListCandidates(ctx, shop, order, from, to, limit, offset)
+		list, total, err := repo.ListCandidates(ctx, shop, order, status, from, to, limit, offset)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -1444,18 +1444,18 @@ func (s *ReconcileService) processShopeeStatusBatch(ctx context.Context, store s
 // CreateReconcileBatches groups reconciliation candidates by store and records
 // them as batch_history rows with associated details. Each batch contains at
 // most 50 invoices. Returns information about the created batches.
-func (s *ReconcileService) CreateReconcileBatches(ctx context.Context, shop, order, from, to string) (*models.ReconcileBatchInfo, error) {
+func (s *ReconcileService) CreateReconcileBatches(ctx context.Context, shop, order, status, from, to string) (*models.ReconcileBatchInfo, error) {
 	if s.batchSvc == nil {
 		return nil, fmt.Errorf("batch service not configured")
 	}
 
-	log.Printf("CreateReconcileBatches: fetching candidates for shop=%s, order=%s, from=%s, to=%s", shop, order, from, to)
+	log.Printf("CreateReconcileBatches: fetching candidates for shop=%s, order=%s, status=%s, from=%s, to=%s", shop, order, status, from, to)
 	pageSize := 1000
 	batchSize := 50 // Process in batches of 50 orders
 	offset := 0
 	all := []models.ReconcileCandidate{}
 	for {
-		list, total, err := s.ListCandidates(ctx, shop, order, from, to, pageSize, offset)
+		list, total, err := s.ListCandidates(ctx, shop, order, status, from, to, pageSize, offset)
 		if err != nil {
 			return nil, err
 		}

--- a/frontend/dropship-erp-ui/src/api/reconcile.ts
+++ b/frontend/dropship-erp-ui/src/api/reconcile.ts
@@ -14,6 +14,7 @@ export function listUnmatched(shop: string) {
 export function listCandidates(
   shop: string,
   order: string,
+  status: string,
   from: string,
   to: string,
   page: number,
@@ -23,6 +24,7 @@ export function listCandidates(
   const q = new URLSearchParams();
   if (shop) q.append("shop", shop);
   if (order) q.append("order", order);
+  if (status) q.append("status", status);
   if (from) q.append("from", from);
   if (to) q.append("to", to);
   q.append("page", String(page));
@@ -77,8 +79,9 @@ export function updateShopeeStatuses(
 export function createReconcileBatch(
   shop: string,
   order: string,
+  status: string,
   from: string,
   to: string,
 ) {
-  return api.post("/reconcile/batch", { shop, order, from, to });
+  return api.post("/reconcile/batch", { shop, order, status, from, to });
 }

--- a/frontend/dropship-erp-ui/src/components/ReconcileDashboard.test.tsx
+++ b/frontend/dropship-erp-ui/src/components/ReconcileDashboard.test.tsx
@@ -65,6 +65,21 @@ test("filter by invoice", async () => {
   await waitFor(() => expect(api.listCandidates).toHaveBeenCalled());
 });
 
+test("filter by status", async () => {
+  render(
+    <MemoryRouter>
+      <ReconcileDashboard />
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(api.listCandidates).toHaveBeenCalled());
+  jest.clearAllMocks();
+  fireEvent.change(screen.getByLabelText(/Status/i), {
+    target: { value: "diproses" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /Refresh/i }));
+  await waitFor(() => expect(api.listCandidates).toHaveBeenCalled());
+});
+
 test("click reconcile button", async () => {
   (api.listCandidates as jest.Mock).mockResolvedValueOnce({
     data: {

--- a/frontend/dropship-erp-ui/src/components/ReconcileDashboard.tsx
+++ b/frontend/dropship-erp-ui/src/components/ReconcileDashboard.tsx
@@ -119,12 +119,13 @@ function renderValue(key: string, value: any): JSX.Element {
 export default function ReconcileDashboard() {
   const [shop, setShop] = useState("");
   const [order, setOrder] = useState("");
+  const [status, setStatus] = useState("");
   const [firstOfMonth, lastOfMonth] = getCurrentMonthRange();
   const [from, setFrom] = useState(firstOfMonth);
   const [to, setTo] = useState(lastOfMonth);
   const [stores, setStores] = useState<Store[]>([]);
   const { data, controls, reload } = useServerPagination((params) =>
-    listCandidates(shop, order, from, to, params.page, params.pageSize).then(
+    listCandidates(shop, order, status, from, to, params.page, params.pageSize).then(
       (r) => r.data,
     ),
   );
@@ -149,7 +150,7 @@ export default function ReconcileDashboard() {
   useEffect(() => {
     reload();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shop, order, from, to]);
+  }, [shop, order, status, from, to]);
 
   const handleReconcile = async (kode: string) => {
     try {
@@ -195,7 +196,7 @@ export default function ReconcileDashboard() {
 
   const handleReconcileAll = async () => {
     try {
-      const response = await createReconcileBatch(shop, order, from, to);
+      const response = await createReconcileBatch(shop, order, status, from, to);
       const data = response.data;
       let message = "Reconcile batches created successfully";
       if (data.batches_created && data.total_transactions) {
@@ -282,6 +283,13 @@ export default function ReconcileDashboard() {
         placeholder="Kode Invoice"
         value={order}
         onChange={(e) => setOrder(e.target.value)}
+        style={{ height: "2rem", marginRight: "0.5rem" }}
+      />
+      <input
+        aria-label="Status"
+        placeholder="Status"
+        value={status}
+        onChange={(e) => setStatus(e.target.value)}
         style={{ height: "2rem", marginRight: "0.5rem" }}
       />
       <LocalizationProvider dateAdapter={AdapterDateFns}>


### PR DESCRIPTION
## Summary
- enable filtering by purchase status in reconcile candidate queries
- extend handler, service and repository for new status parameter
- update React dashboard UI and API calls to send status
- document status filter in README

## Testing
- `gofmt -w internal/handlers/reconcile_extra_handler.go internal/repository/reconcile_repo.go internal/service/reconcile_service.go internal/repository/reconcile_repo_test.go`
- `go test ./...`
- `npm run lint` *(fails: cannot find `@eslint/js`)*
- `npm test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6877ce065dc083278b3a3325e6875829